### PR TITLE
Handle trailing slashes when normalizing API roots

### DIFF
--- a/R/models_cache.R
+++ b/R/models_cache.R
@@ -15,8 +15,9 @@
 # Strips trailing slashes and removes accidental inclusion of /v1, /chat/completions, etc.
 # Always returns just the root (e.g., "http://127.0.0.1:1234").
 .api_root <- function(x) {
-  x <- sub("(/v1/chat/completions)?$", "", x)
-  x <- sub("(/v1/models)?$", "", x)
+  # remove common API suffixes with or without trailing slash
+  x <- sub("(/v1/(chat/completions|models))/?$", "", x)
+  x <- sub("/v1/?$", "", x)
   x <- sub("/+$", "", x)
   x
 }

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -151,8 +151,10 @@ ollama_tags_payload <- function() {
 test_that(".api_root - normalizes urls", {
   f <- getFromNamespace(".api_root", "gptr")
   expect_equal(f("http://127.0.0.1:1234/v1/chat/completions"), "http://127.0.0.1:1234")
+  expect_equal(f("http://127.0.0.1:1234/v1/chat/completions/"), "http://127.0.0.1:1234")
   expect_equal(f("http://127.0.0.1:1234////v1/chat/completions"), "http://127.0.0.1:1234")
   expect_equal(f("https://api.openai.com/v1/models"), "https://api.openai.com")
+  expect_equal(f("https://api.openai.com/v1/models/"), "https://api.openai.com")
 })
 
 


### PR DESCRIPTION
## Summary
- fix `.api_root()` so it removes `/v1/chat/completions/` and `/v1/models/` suffixes
- extend test coverage for `.api_root()` trailing slash cases

## Testing
- `Rscript -e 'testthat::test_dir("tests")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b40c5219d08321a745cb14ab304d02