### PR TITLE
Use cachem for model caching

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,10 +31,13 @@ Imports:
     curl (>= 5.0.0),
     rlang,
     stats,
-    utils
-Suggests: 
+    utils,
+    cachem,
+    digest
+Suggests:
     testthat (>= 3.0.0),
-    progressr
+    progressr,
+    withr
 Config/testthat/edition: 3
 URL: https://github.com/FrancescoMonti-source/gptr
 BugReports: https://github.com/FrancescoMonti-source/gptr/issues

--- a/R/models_cache.R
+++ b/R/models_cache.R
@@ -7,7 +7,19 @@
 #   gptr.localai_base_url  = "http://127.0.0.1:8080"
 # )
 
-.gptr_cache <- new.env(parent = emptyenv())
+# memory cache for model lists
+.gptr_cache <- cachem::cache_mem()
+
+#' Snapshot of the current models cache
+#'
+#' Returns a named list of cache entries for testing/inspection.
+#' @keywords internal
+.models_cache_snapshot <- function() {
+  keys <- .gptr_cache$keys()
+  entries <- lapply(keys, function(k) .gptr_cache$get(k))
+  names(entries) <- vapply(entries, function(e) paste0(e$provider, "::", e$base_url), character(1))
+  entries
+}
 
 # --- URL helpers -------------------------------------------------------------
 
@@ -195,28 +207,36 @@
 
 # Construct a unique cache key string from provider+base_url.
 .cache_key <- function(provider, base_url) {
-  paste0(provider, "::", .api_root(base_url))
+  raw <- paste0(provider, "::", .api_root(base_url))
+  digest::digest(raw, algo = "md5")
 }
 
 # Look up a cached entry in .gptr_cache by provider+base_url.
-# Returns NULL if not cached.
+# Returns NULL if not cached or expired.
 .cache_get <- function(provider, base_url) {
-    root <- .api_root(base_url)
-    key  <- paste0(provider, "::", root)
-    .gptr_cache[[key]] %||% NULL
+  key <- .cache_key(provider, base_url)
+  .gptr_cache$get(key)
 }
 
 #' Save a cache entry for provider+base_url with a vector of model IDs and timestamp.
+#' The TTL is managed by cachem; if `gptr.check_model_once` is TRUE the entry
+#' never expires, otherwise `gptr.model_cache_ttl` (seconds) is used.
 #' @keywords internal
 .cache_put <- function(provider, base_url, models) {
-    root <- .api_root(base_url)
-    key  <- paste0(provider, "::", root)
-    .gptr_cache[[key]] <- list(models = models,
-                               ts = as.POSIXct(as.numeric(Sys.time()),
-                                               origin = "1970-01-01",
-                                               tz = "Europe/Paris")
-                               )
-    invisible(TRUE)
+  key <- .cache_key(provider, base_url)
+  ttl <- if (isTRUE(getOption("gptr.check_model_once", TRUE))) {
+    Inf
+  } else {
+    getOption("gptr.model_cache_ttl", 3600)
+  }
+  ent <- list(
+    provider = provider,
+    base_url = .api_root(base_url),
+    models = models,
+    ts = as.numeric(Sys.time())
+  )
+  .gptr_cache$set(key, ent, ttl = ttl)
+  invisible(TRUE)
 }
 
 #' Remove a cache entry for provider+base_url from .gptr_cache.
@@ -224,18 +244,11 @@
 #' @keywords internal
 .cache_del <- function(provider, base_url) {
   key <- .cache_key(provider, base_url)
-  if (!exists(key, envir = .gptr_cache, inherits = FALSE)) {
+  if (!.gptr_cache$exists(key)) {
     return(0L)
   }
-  rm(list = key, envir = .gptr_cache)
+  .gptr_cache$remove(key)
   1L
-}
-
-#' @keywords internal
-.parse_cache_key <- function(key) {
-  # key format: "<provider>::<root>"
-  parts <- strsplit(key, "::", fixed = TRUE)[[1]]
-  list(provider = parts[[1]], base_url = parts[[2]])
 }
 
 #' @noRd
@@ -243,7 +256,7 @@
 .list_models_cached <- function(provider = NULL, base_url = NULL) {
     # Case A: both missing -> enumerate everything currently cached (summary view)
     if (is.null(provider) && is.null(base_url)) {
-        keys <- ls(.gptr_cache, all.names = TRUE)
+        keys <- .gptr_cache$keys()
         if (!length(keys)) {
             return(data.frame(
                 provider   = character(),
@@ -254,11 +267,10 @@
             ))
         }
         rows <- lapply(keys, function(k) {
-            ent  <- .gptr_cache[[k]]
-            meta <- .parse_cache_key(k)  # "<provider>::<base_url_root>"
+            ent  <- .gptr_cache$get(k)
             data.frame(
-                provider  = meta$provider,
-                base_url  = meta$base_url,
+                provider  = ent$provider,
+                base_url  = ent$base_url,
                 n_models  = length(ent$models %||% character(0)),
                 cached_at = if (!is.null(ent$ts)) {
                     as.POSIXct(ent$ts, origin = "1970-01-01", tz = "Europe/Paris")
@@ -282,20 +294,16 @@
     # Case C: only base_url
     if (is.null(provider) && !is.null(base_url)) {
         root <- .api_root(base_url)
-        keys <- ls(.gptr_cache, all.names = TRUE)
-        hits <- vapply(keys, function(k) .parse_cache_key(k)$base_url == root, logical(1))
+        keys <- .gptr_cache$keys()
+        hits <- vapply(keys, function(k) .gptr_cache$get(k)$base_url == root, logical(1))
         if (!any(hits)) return(character(0))
-        models <- unique(unlist(lapply(keys[hits], function(k) .gptr_cache[[k]]$models), use.names = FALSE))
+        models <- unique(unlist(lapply(keys[hits], function(k) .gptr_cache$get(k)$models), use.names = FALSE))
         return(models %||% character(0))
     }
 
-    # Case D: provider + base_url with TTL behavior
+    # Case D: provider + base_url with cachem TTL
     ent <- .cache_get(provider, base_url)
-    if (!is.null(ent)) {
-        if (isTRUE(getOption("gptr.check_model_once", TRUE))) return(ent$models)
-        ttl <- getOption("gptr.model_cache_ttl", 3600)
-        if (!is.na(ent$ts) && (as.numeric(Sys.time()) - ent$ts) < ttl) return(ent$models)
-    }
+    if (!is.null(ent)) return(ent$models)
     models <- .fetch_models_live(provider, base_url)
     .cache_put(provider, base_url, models)
     models
@@ -490,41 +498,15 @@ refresh_models_cache <- function(provider = NULL, base_url = NULL) {
 #' @return integer: number of entries removed
 #' @export
 delete_models_cache <- function(provider = NULL, base_url = NULL) {
-    keys <- ls(.gptr_cache, all.names = TRUE)
+    keys <- .gptr_cache$keys()
     if (!length(keys)) return(invisible(TRUE))
 
-    # no args: clear everything
-    if (is.null(provider) && is.null(base_url)) {
-        for (k in keys) {
-            parts <- .parse_cache_key(k)
-            .cache_del(parts$provider, parts$base_url)
-        }
-        return(invisible(TRUE))
+    for (k in keys) {
+        ent <- .gptr_cache$get(k)
+        match_provider <- is.null(provider) || identical(ent$provider, provider)
+        match_base <- is.null(base_url) || identical(.api_root(ent$base_url), .api_root(base_url))
+        if (match_provider && match_base) .gptr_cache$remove(k)
     }
-
-    # provider only
-    if (!is.null(provider) && is.null(base_url)) {
-        for (k in keys) {
-            parts <- .parse_cache_key(k)
-            if (identical(parts$provider, provider))
-                .cache_del(parts$provider, parts$base_url)
-        }
-        return(invisible(TRUE))
-    }
-
-    # base_url only
-    if (is.null(provider) && !is.null(base_url)) {
-        root <- .api_root(base_url)
-        for (k in keys) {
-            parts <- .parse_cache_key(k)
-            if (identical(.api_root(parts$base_url), root))
-                .cache_del(parts$provider, parts$base_url)
-        }
-        return(invisible(TRUE))
-    }
-
-    # both
-    .cache_del(provider, .api_root(base_url))
     invisible(TRUE)
 }
 

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -182,6 +182,19 @@ test_that("cache put / get / del", {
   expect_null(get("openai", "https://api.openai.com"))
 })
 
+test_that("cache entries expire after TTL", {
+  get <- getFromNamespace(".cache_get", "gptr")
+  put <- getFromNamespace(".cache_put", "gptr")
+  del <- getFromNamespace(".cache_del", "gptr")
+
+  withr::local_options(list(gptr.check_model_once = FALSE, gptr.model_cache_ttl = 1))
+  put("openai", "https://api.openai.com", data.frame(id = "x", created = 1))
+  expect_false(is.null(get("openai", "https://api.openai.com")))
+  Sys.sleep(2)
+  expect_null(get("openai", "https://api.openai.com"))
+  del("openai", "https://api.openai.com")
+})
+
 # models cache snapshot immutability
 test_that("cache snapshot - immutability", {
   snap <- getFromNamespace(".models_cache_snapshot", "gptr")


### PR DESCRIPTION
## Summary
- switch model cache to `cachem::cache_mem` and expose snapshot helper
- refactor cache helpers to use cachem API with TTL support
- add tests for cache TTL expiry and list `cachem` in package imports
- hash cache keys and retain provider/base URL metadata for enumeration and invalidation

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_68b40cc30b308321818308af66e8d8bb