### PR TITLE
Remove obsolete gpt_clear_caches helper

### DIFF
--- a/R/utils-cache.R
+++ b/R/utils-cache.R
@@ -1,22 +1,3 @@
-#' #' Clear gptr internal caches (backend detection, model list, ping)
-#' #'
-#' #' Useful in tests to ensure a clean state.
-#' gpt_clear_caches <- function() {
-#'   .gptr_state$detected_backend <- NULL
-#'   .gptr_state$models_cache <- NULL
-#'   .gptr_state$models_base <- NULL
-#'   .gptr_state$warned_missing <- FALSE
-#'   .gptr_state$ping_cache <- new.env(parent = emptyenv())
-#'   invisible(TRUE)
-#' }
-#'
-#'
-#' gpt_refresh_models <- function(base_url = getOption("gptr.local_base_url", NULL)) {
-#'   if (is.null(base_url) || !nzchar(base_url)) stop("Provide base_url or set options(gptr.local_base_url).", call. = FALSE)
-#'   invisible(.get_model_ids(base_url, force = TRUE))
-#' }
-#'
-#'
 #' list_models() helprer
 #' @keywords internal
 .as_models_df <- function(x) {

--- a/man/dot-as_models_df.Rd
+++ b/man/dot-as_models_df.Rd
@@ -2,27 +2,11 @@
 % Please edit documentation in R/utils-cache.R
 \name{.as_models_df}
 \alias{.as_models_df}
-\title{#' Clear gptr internal caches (backend detection, model list, ping)
-#'
-#' Useful in tests to ensure a clean state.
-gpt_clear_caches <- function() {
-.gptr_state$detected_backend <- NULL
-.gptr_state$models_cache <- NULL
-.gptr_state$models_base <- NULL
-.gptr_state$warned_missing <- FALSE
-.gptr_state$ping_cache <- new.env(parent = emptyenv())
-invisible(TRUE)
-}}
+\title{list_models() helprer}
 \usage{
 .as_models_df(x)
 }
 \description{
-gpt_refresh_models <- function(base_url = getOption("gptr.local_base_url", NULL)) {
-if (is.null(base_url) || !nzchar(base_url)) stop("Provide base_url or set options(gptr.local_base_url).", call. = FALSE)
-invisible(.get_model_ids(base_url, force = TRUE))
-}
-}
-\details{
 list_models() helprer
 }
 \keyword{internal}


### PR DESCRIPTION
## Summary
- drop unused `gpt_clear_caches` references from cache utilities
- prune stale documentation for `.as_models_df`

## Testing
- `R -q -e "devtools::document()"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b588b34148832195fb57e2be0fb851