### PR TITLE
Use cachem for model caching

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,8 @@ Imports:
     curl (>= 5.0.0),
     rlang,
     stats,
-    utils
+    utils,
+    cachem
 Suggests: 
     testthat (>= 3.0.0),
     progressr

--- a/man/delete_models_cache.Rd
+++ b/man/delete_models_cache.Rd
@@ -2,17 +2,13 @@
 % Please edit documentation in R/models_cache.R
 \name{delete_models_cache}
 \alias{delete_models_cache}
-\title{Clear cache entries so that the next run will re-probe the server.
-Takes optional provider and/or base_url to scope the invalidation.
-Returns the number of entries removed.}
+\title{Resets the models cache so that the next run will re-probe the server.}
 \usage{
-delete_models_cache(provider = NULL, base_url = NULL)
+delete_models_cache()
 }
 \value{
-integer: number of entries removed
+invisible TRUE
 }
 \description{
-Clear cache entries so that the next run will re-probe the server.
-Takes optional provider and/or base_url to scope the invalidation.
-Returns the number of entries removed.
+Resets the models cache so that the next run will re-probe the server.
 }

--- a/man/dot-cache_del.Rd
+++ b/man/dot-cache_del.Rd
@@ -2,13 +2,11 @@
 % Please edit documentation in R/models_cache.R
 \name{.cache_del}
 \alias{.cache_del}
-\title{Remove a cache entry for provider+base_url from .gptr_cache.
-Returns 1 if removed, 0 if nothing existed.}
+\title{Remove a cache entry for provider+base_url from the cache.}
 \usage{
 .cache_del(provider, base_url)
 }
 \description{
-Remove a cache entry for provider+base_url from .gptr_cache.
-Returns 1 if removed, 0 if nothing existed.
+Remove a cache entry for provider+base_url from the cache.
 }
 \keyword{internal}


### PR DESCRIPTION
## Summary
- add `cachem` dependency
- switch models cache to `cachem` with TTL support
- update cache helpers and tests for cachem API

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y r-base` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b588ab525c8321a30f7a4dd3856d23