### PR TITLE
Coalesce missing cache timestamp

### DIFF
--- a/R/utils-cache.R
+++ b/R/utils-cache.R
@@ -54,6 +54,7 @@
 .row_df <- function(provider, base_url, models_df, availability, src, ts, status = NA_character_) {
     base_url <- .api_root(base_url)
     models_df <- .as_models_df(models_df)
+    ts <- if (length(ts)) ts else NA_real_  # coalesce: legacy cache entries may omit ts
     if (nrow(models_df) == 0) {
         return(data.frame(
             provider = provider,


### PR DESCRIPTION
## Summary
- Ensure `.row_df()` coalesces missing timestamps to `NA_real_` so `cached_at` always has length 1.
- Document the coalescing to handle legacy cache entries that lacked `ts`.

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden when trying to install R)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a41190448321aadf96ac7fe721d7