### PR TITLE
Handle empty model listings correctly

### DIFF
--- a/R/utils-cache.R
+++ b/R/utils-cache.R
@@ -57,14 +57,14 @@
     ts <- if (length(ts)) ts else NA_real_  # coalesce: legacy cache entries may omit ts
     if (nrow(models_df) == 0) {
         return(data.frame(
-            provider = provider,
-            base_url = base_url,
-            model_id = NA_character_,
-            created = NA_real_,
-            availability = availability,
-            cached_at = as.POSIXct(ts, origin = "1970-01-01", tz = "Europe/Paris"),
-            source = src,
-            status = status,
+            provider = character(),
+            base_url = character(),
+            model_id = character(),
+            created = numeric(),
+            availability = character(),
+            cached_at = as.POSIXct(numeric(), origin = "1970-01-01", tz = "Europe/Paris"),
+            source = character(),
+            status = character(),
             stringsAsFactors = FALSE
         ))
     }

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -248,7 +248,7 @@ test_that("cache snapshot - immutability", {
   expect_false(identical(s1, s2))
 })
 
-test_that("refresh writes cache and surfaces status", {
+test_that("refresh with no models returns empty data", {
   fake_cache <- make_fake_cache()
   local_mocked_bindings(
     .cache_get = function(p, u) fake_cache$get(p, u),
@@ -258,7 +258,7 @@ test_that("refresh writes cache and surfaces status", {
     .api_root = function(x) x
   )
   out <- list_models(provider = "lmstudio", refresh = TRUE)
-  expect_true(any(out$status == "refreshed"))
+  expect_equal(nrow(out), 0)
 })
 
 
@@ -364,6 +364,13 @@ test_that(".row_df repeats provider/base/url and status", {
   expect_equal(unique(r$provider), "openai")
   expect_equal(nrow(r), 2)
   expect_equal(r$status, rep("ok", 2))
+})
+
+test_that(".row_df returns zero rows when no models", {
+  f <- getFromNamespace(".row_df", "gptr")
+  r <- f("openai", "https://api.openai.com", data.frame(id = character(), created = numeric()),
+         "catalog", "live", fixed_ts, status = "ok")
+  expect_equal(nrow(r), 0)
 })
 
 


### PR DESCRIPTION
## Summary
- Return empty data frame from `.row_df()` when no models are present
- Adjust list model cache tests for zero-row results
- Add regression test for `.row_df()` zero-row behavior

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5aeb68c948321b676ceec1e131a0e