### PR TITLE
Fix trailing commas in refresh_models_cache

### DIFF
--- a/R/models_cache.R
+++ b/R/models_cache.R
@@ -471,7 +471,7 @@ refresh_models_cache <- function(provider = NULL,
                 models_count = nrow(live$df),
                 refreshed_at = as.POSIXct(Sys.time(), tz = "Europe/Paris"),
                 status       = live$status,
-                stringsAsFactors = FALSE,
+                stringsAsFactors = FALSE
             )
         } else {
             bu     <- base_url %||% cand$base_url
@@ -485,7 +485,7 @@ refresh_models_cache <- function(provider = NULL,
                 # keep it POSIXct from the start
                 refreshed_at = as.POSIXct(Sys.time(), tz = "Europe/Paris"),
                 status       = if (length(models)) "ok" else "unreachable_or_empty",
-                stringsAsFactors = FALSE,
+                stringsAsFactors = FALSE
             )
         }
     }


### PR DESCRIPTION
## Summary
- drop trailing commas from data.frame() constructions in refresh_models_cache

## Testing
- `Rscript -e "roxygen2::roxygenise()"` *(fails: command not found)*
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b351875c83218e076b329273b7d3