### PR TITLE
Propagate status for empty model listings

### DIFF
--- a/R/utils-cache.R
+++ b/R/utils-cache.R
@@ -56,6 +56,19 @@
     models_df <- .as_models_df(models_df)
     ts <- if (length(ts)) ts else NA_real_  # coalesce: legacy cache entries may omit ts
     if (nrow(models_df) == 0) {
+        if (!is.na(status)) {
+            return(data.frame(
+                provider = provider,
+                base_url = base_url,
+                model_id = NA_character_,
+                created = NA_real_,
+                availability = availability,
+                cached_at = as.POSIXct(ts, origin = "1970-01-01", tz = "Europe/Paris"),
+                source = src,
+                status = status,
+                stringsAsFactors = FALSE
+            ))
+        }
         return(data.frame(
             provider = character(),
             base_url = character(),

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -366,11 +366,20 @@ test_that(".row_df repeats provider/base/url and status", {
   expect_equal(r$status, rep("ok", 2))
 })
 
-test_that(".row_df returns zero rows when no models", {
+test_that(".row_df returns zero rows when no models and status is NA", {
   f <- getFromNamespace(".row_df", "gptr")
   r <- f("openai", "https://api.openai.com", data.frame(id = character(), created = numeric()),
-         "catalog", "live", fixed_ts, status = "ok")
+         "catalog", "live", fixed_ts)
   expect_equal(nrow(r), 0)
+})
+
+test_that(".row_df preserves status when no models", {
+  f <- getFromNamespace(".row_df", "gptr")
+  r <- f("openai", "https://api.openai.com", data.frame(id = character(), created = numeric()),
+         "catalog", "live", fixed_ts, status = "auth_missing")
+  expect_equal(nrow(r), 1)
+  expect_true(is.na(r$model_id))
+  expect_equal(r$status, "auth_missing")
 })
 
 


### PR DESCRIPTION
## Summary
- Return a status row when `.row_df()` receives no models but a non-`NA` status
- Test `.row_df()` behavior for both `NA` and non-`NA` statuses

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b3d8abfc8321a8b2f80a682a5191