### PR TITLE
Align model cache refresh with list_models output

### DIFF
--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -253,7 +253,19 @@ test_that("refresh with no models returns empty data", {
   local_mocked_bindings(
     .cache_get = function(p, u) fake_cache$get(p, u),
     .cache_put = function(p, u, m) fake_cache$put(p, u, m),
-    refresh_models_cache = function(provider, base_url) list(status = "refreshed"),
+    refresh_models_cache = function(provider, base_url) {
+      data.frame(
+        provider = character(),
+        base_url = character(),
+        model_id = character(),
+        created = numeric(),
+        availability = character(),
+        cached_at = as.POSIXct(numeric(), origin = "1970-01-01", tz = "Europe/Paris"),
+        source = character(),
+        status = character(),
+        stringsAsFactors = FALSE
+      )
+    },
     .list_models_cached = function(...) data.frame(id = character(0), created = numeric(0)),
     .api_root = function(x) x
   )
@@ -335,9 +347,9 @@ test_that("refresh_models_cache handles openai provider", {
     .env = asNamespace("gptr")
   )
   out <- refresh_models_cache(provider = "openai", openai_api_key = "sk-test")
-  expect_equal(out$provider, "openai")
-  expect_equal(out$models_count, 2L)
-  expect_equal(out$status, "ok")
+  expect_true(all(out$provider == "openai"))
+  expect_equal(nrow(out), 2L)
+  expect_true(all(out$status == "ok"))
   cached <- fake_cache$get("openai", "https://api.openai.com")
   expect_true(NROW(cached$models) == 2)
 })
@@ -354,7 +366,8 @@ test_that("refresh_models_cache skips cache when unreachable", {
     .env = asNamespace("gptr")
   )
   out <- refresh_models_cache(provider = "lmstudio", base_url = "http://127.0.0.1:1234")
-  expect_equal(out$status, "unreachable")
+  expect_true(all(out$status == "unreachable"))
+  expect_true(all(is.na(out$model_id)))
   expect_null(fake_cache$get("lmstudio", "http://127.0.0.1:1234"))
 })
 
@@ -376,7 +389,9 @@ test_that("refresh_models_cache retries after unreachable and caches", {
     .env = asNamespace("gptr")
   )
   out <- refresh_models_cache(provider = "lmstudio", base_url = "http://127.0.0.1:1234")
+  expect_equal(nrow(out), 1L)
   expect_equal(out$status, "ok")
+  expect_equal(out$model_id, "m1")
   cached <- fake_cache$get("lmstudio", "http://127.0.0.1:1234")
   expect_identical(NROW(cached$models), 1L)
 })


### PR DESCRIPTION
## Summary
- Use `refresh_models_cache()` to return the same columns as `list_models()`
- Simplify `list_models(refresh = TRUE)` to reuse `refresh_models_cache`
- Expand tests for refresh behavior and unreachable retries

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b6257bee308321b98d4d74cfcc8fbb