### PR TITLE
Refine cache deletion and normalize timestamps

### DIFF
--- a/R/state.R
+++ b/R/state.R
@@ -1,8 +1,6 @@
 .gptr_state <- local({
   e <- new.env(parent = emptyenv())
   e$detected_backend <- NULL
-  e$models_cache <- NULL
-  e$models_base <- NULL
   e$warned_missing <- FALSE
   e$ping_cache <- new.env(parent = emptyenv()) # base_root -> TRUE/FALSE
   e

--- a/R/utils-cache.R
+++ b/R/utils-cache.R
@@ -63,7 +63,7 @@
                 model_id = NA_character_,
                 created = NA_real_,
                 availability = availability,
-                cached_at = as.POSIXct(ts, origin = "1970-01-01", tz = "Europe/Paris"),
+                cached_at = as.POSIXct(ts, origin = "1970-01-01", tz = "UTC"),
                 source = src,
                 status = status,
                 stringsAsFactors = FALSE
@@ -75,7 +75,7 @@
             model_id = character(),
             created = numeric(),
             availability = character(),
-            cached_at = as.POSIXct(numeric(), origin = "1970-01-01", tz = "Europe/Paris"),
+            cached_at = as.POSIXct(numeric(), origin = "1970-01-01", tz = "UTC"),
             source = character(),
             status = character(),
             stringsAsFactors = FALSE
@@ -87,7 +87,7 @@
         model_id = models_df$id,
         created = models_df$created,
         availability = availability,
-        cached_at = as.POSIXct(ts, origin = "1970-01-01", tz = "Europe/Paris"),
+        cached_at = as.POSIXct(ts, origin = "1970-01-01", tz = "UTC"),
         source = src,
         status = status,
         stringsAsFactors = FALSE


### PR DESCRIPTION
## Summary
- use UTC for cache timestamps and created-at columns
- drop unused state variables
- support selective cache invalidation without parsing cache keys
- expand cache tests for enumeration and targeted deletion

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e5699468832193b2007b716bfd6e