### PR TITLE
Add build_prompt tests

### DIFF
--- a/tests/testthat/test-build_prompt.R
+++ b/tests/testthat/test-build_prompt.R
@@ -1,0 +1,19 @@
+test_that("build_prompt renders template with keys", {
+  template <- "{text} -> {json_format}"
+  keys <- list(a = "integer", b = "numeric")
+  res <- build_prompt(template, text = "hello", keys = keys)
+  expect_equal(res, "hello -> { a: \"0\"|\"1\"|\"NA\", b: a number (ex: 3.14) }")
+})
+
+test_that("build_prompt omits json_format when keys is NULL", {
+  template <- "{text} -> {json_format}"
+  res <- build_prompt(template, text = "hello", keys = NULL)
+  expect_equal(res, "hello -> ")
+})
+
+test_that("build_prompt handles empty text", {
+  template <- "{text} -> {json_format}"
+  expect_equal(build_prompt(template, text = "", keys = NULL), "Texte manquant")
+  expect_equal(build_prompt(template, text = NA, keys = NULL), "Texte manquant")
+  expect_equal(build_prompt(template, text = NULL, keys = NULL), "Texte manquant")
+})


### PR DESCRIPTION
## Summary
- test build_prompt with schema keys and verify json_format injection
- ensure json_format is omitted when no keys are provided
- confirm empty text and missing values return "Texte manquant"

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ee1f51948321854234638fa37ecb