### PR TITLE
Move pkgnet to suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,6 @@ Imports:
     glue,
     purrr,
     tools,
-    pkgnet,
     cli,
     curl (>= 5.0.0),
     rlang,
@@ -36,7 +35,8 @@ Imports:
     digest
 Suggests: 
     testthat (>= 3.0.0),
-    progressr
+    progressr,
+    pkgnet
 Config/testthat/edition: 3
 URL: https://github.com/FrancescoMonti-source/gptr
 BugReports: https://github.com/FrancescoMonti-source/gptr/issues


### PR DESCRIPTION
## Summary
- move `pkgnet` from Imports to Suggests so it's optional

## Testing
- `R -q -e 'devtools::document()'` *(fails: command not found: R)*
- `R -q -e 'devtools::check()'` *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ee0462388321ad739f0f09da3694