### PR TITLE
chore: remove .gitignore backup

### DIFF
--- a/.gitignore.bak
+++ b/.gitignore.bak
@@ -1,6 +1,0 @@
-.Rproj.user
-.Rhistory
-.RData
-.Ruserdata
-docs
-bilan preop


### PR DESCRIPTION
## Summary
- remove obsolete `.gitignore.bak`

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found: R)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f1cf89688321a61914c88a924351