### PR TITLE
docs: update license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ gpt("ping", provider = "lmstudio", model = "mistralai/mistral-7b-instruct-v0.3")
 
 ## 📄 License
 
-MIT License — see [LICENSE.md](LICENSE.md)
+MIT License — see [LICENSE.txt](LICENSE.txt)
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- fix license link in README to reference LICENSE.txt

## Testing
- `R -q -e 'devtools::test()'` (fails: R command not found)
- `apt-get update` (fails: repository is not signed)


------
https://chatgpt.com/codex/tasks/task_e_68b6f6da03dc832185db62e81948da75