### PR TITLE
Raise error when local model missing under strict_model

### DIFF
--- a/R/gpt.R
+++ b/R/gpt.R
@@ -218,7 +218,7 @@ gpt <- function(prompt,
 
         requested_model <- model %||% getOption("gptr.local_model", if (length(ids)) ids[[1]] else "mistralai/mistral-7b-instruct-v0.3")
 
-        if (nzchar(requested_model) && length(ids) && !tolower(requested_model) %in% tolower(ids)) {
+        if (nzchar(requested_model) && (!length(ids) || !tolower(requested_model) %in% tolower(ids))) {
             msg <- sprintf("Model '%s' not found on %s.", requested_model, base_root)
             if (isTRUE(strict_model)) stop(msg, call. = FALSE) else warning(msg, call. = FALSE)
         }

--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -194,9 +194,9 @@ test_that("strict_model errors when model not installed (local)", {
     with_mocked_bindings(
         list_models = function(refresh = FALSE, provider = NULL, base_url = NULL, ...) {
             data.frame(
-                provider  = "lmstudio",
-                base_url  = "http://127.0.0.1:1234",
-                model_id  = "mistralai/mistral-7b-instruct-v0.3",
+                provider  = character(),
+                base_url  = character(),
+                model_id  = character(),
                 stringsAsFactors = FALSE
             )
         },


### PR DESCRIPTION
## Summary
- Ensure `gpt()` stops when a requested local model is absent even if no models are reported
- Test `strict_model` enforcement when no local models are available

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f8bf775c8321bb132dfac4ddf22c