### PR TITLE
Refine model cache helpers

### DIFF
--- a/R/models_cache.R
+++ b/R/models_cache.R
@@ -223,7 +223,7 @@
 # Look up a cached entry in .gptr_cache by provider+base_url.
 # Returns NULL if not cached.
 .cache_get <- function(provider, base_url) {
-  .gptr_cache$get(.cache_key(provider, base_url))
+  .gptr_cache$get(.cache_key(provider, base_url), missing = NULL)
 }
 
 #' Save a cache entry for provider+base_url with a vector of model IDs and timestamp.
@@ -233,7 +233,7 @@
     provider = provider,
     base_url = .api_root(base_url),
     models   = models,
-    ts       = as.POSIXct(as.numeric(Sys.time()), origin = "1970-01-01", tz = "UTC")
+    ts       = as.numeric(Sys.time())
   )
   if (isTRUE(getOption("gptr.check_model_once", TRUE))) {
     .gptr_cache$set(.cache_key(provider, base_url), entry)
@@ -272,7 +272,10 @@
             ))
         }
         rows <- lapply(keys, function(k) {
-            ent <- .gptr_cache$get(k)
+            ent <- .gptr_cache$get(k, missing = NULL)
+            if (is.null(ent)) {
+                return(NULL)
+            }
             data.frame(
                 provider  = ent$provider %||% NA_character_,
                 base_url  = ent$base_url %||% NA_character_,
@@ -285,6 +288,16 @@
                 stringsAsFactors = FALSE
             )
         })
+        rows <- Filter(Negate(is.null), rows)
+        if (!length(rows)) {
+            return(data.frame(
+                provider   = character(),
+                base_url   = character(),
+                n_models   = integer(),
+                cached_at  = as.POSIXct(character(), tz = "UTC"),
+                stringsAsFactors = FALSE
+            ))
+        }
         return(do.call(rbind, rows))
     }
 
@@ -301,13 +314,17 @@
         root <- .api_root(base_url)
         keys <- .gptr_cache$keys()
         hits <- vapply(keys, function(k) {
-            ent <- .gptr_cache$get(k)
-            identical(ent$base_url, root)
+            ent <- .gptr_cache$get(k, missing = NULL)
+            !is.null(ent) && identical(ent$base_url, root)
         }, logical(1))
 
         if (!any(hits)) return(character(0))
         models <- unique(unlist(lapply(keys[hits], function(k) {
-            .as_models_df(.gptr_cache$get(k)$models)$id
+            ent <- .gptr_cache$get(k, missing = NULL)
+            if (is.null(ent)) {
+                return(character(0))
+            }
+            .as_models_df(ent$models)$id
         }), use.names = FALSE))
         return(models %||% character(0))
     }
@@ -489,7 +506,7 @@ delete_models_cache <- function(provider = NULL, base_url = NULL) {
     # provider only
     if (!is.null(provider) && is.null(base_url)) {
         for (k in keys) {
-            ent <- .gptr_cache$get(k)
+            ent <- .gptr_cache$get(k, missing = NULL)
             if (!is.null(ent) && identical(ent$provider, provider)) {
                 .gptr_cache$remove(k)
             }
@@ -501,7 +518,7 @@ delete_models_cache <- function(provider = NULL, base_url = NULL) {
     if (is.null(provider) && !is.null(base_url)) {
         root <- .api_root(base_url)
         for (k in keys) {
-            ent <- .gptr_cache$get(k)
+            ent <- .gptr_cache$get(k, missing = NULL)
             if (!is.null(ent) && identical(ent$base_url, root)) {
                 .gptr_cache$remove(k)
             }

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -135,7 +135,7 @@ make_fake_cache <- function() {
   list(
     get = function(provider, base_url) {
       key <- key_fun(provider, .cache_root_for_test(base_url))
-      store$get(key)
+      store$get(key, missing = NULL)
     },
     put = function(provider, base_url, models) {
       root <- .cache_root_for_test(base_url)
@@ -476,9 +476,9 @@ test_that("invalidate clears cache", {
   cache$set(key_fun("openai", base),
             list(provider = "openai", base_url = base,
                  models = data.frame(id = "x", created = 1), ts = 1))
-  expect_false(is.null(cache$get(key_fun("openai", base))))
+  expect_false(is.null(cache$get(key_fun("openai", base), missing = NULL)))
   inv()
-  expect_null(cache$get(key_fun("openai", base)))
+  expect_null(cache$get(key_fun("openai", base), missing = NULL))
 })
 
 test_that("delete_models_cache removes by provider", {
@@ -491,8 +491,8 @@ test_that("delete_models_cache removes by provider", {
   cache$set(key_fun("lmstudio", "http://127.0.0.1:1234"),
             list(provider = "lmstudio", base_url = "http://127.0.0.1:1234", models = list(), ts = 1))
   inv(provider = "openai")
-  expect_null(cache$get(key_fun("openai", "https://api.openai.com")))
-  expect_false(is.null(cache$get(key_fun("lmstudio", "http://127.0.0.1:1234"))))
+  expect_null(cache$get(key_fun("openai", "https://api.openai.com"), missing = NULL))
+  expect_false(is.null(cache$get(key_fun("lmstudio", "http://127.0.0.1:1234"), missing = NULL)))
 })
 
 test_that("delete_models_cache removes by base_url", {
@@ -505,8 +505,8 @@ test_that("delete_models_cache removes by base_url", {
   cache$set(key_fun("openai", "https://alt.openai.com"),
             list(provider = "openai", base_url = "https://alt.openai.com", models = list(), ts = 1))
   inv(base_url = "https://api.openai.com")
-  expect_null(cache$get(key_fun("openai", "https://api.openai.com")))
-  expect_false(is.null(cache$get(key_fun("openai", "https://alt.openai.com"))))
+  expect_null(cache$get(key_fun("openai", "https://api.openai.com"), missing = NULL))
+  expect_false(is.null(cache$get(key_fun("openai", "https://alt.openai.com"), missing = NULL)))
 })
 
 test_that("delete_models_cache removes by provider and base_url", {
@@ -519,8 +519,8 @@ test_that("delete_models_cache removes by provider and base_url", {
   cache$set(key_fun("openai", "https://alt.openai.com"),
             list(provider = "openai", base_url = "https://alt.openai.com", models = list(), ts = 1))
   inv(provider = "openai", base_url = "https://api.openai.com")
-  expect_null(cache$get(key_fun("openai", "https://api.openai.com")))
-  expect_false(is.null(cache$get(key_fun("openai", "https://alt.openai.com"))))
+  expect_null(cache$get(key_fun("openai", "https://api.openai.com"), missing = NULL))
+  expect_false(is.null(cache$get(key_fun("openai", "https://alt.openai.com"), missing = NULL)))
 })
 
 


### PR DESCRIPTION
## Summary
- Guard cache listing against missing entries
- Store cache timestamps as numeric and return NULL for missing keys
- Support targeted cache deletion by provider or base URL

## Testing
- `R -q -e 'testthat::test_package("gptr")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f933cbfc8321a682031ac512b25f