### PR TITLE
Simplify local model cache normalization

### DIFF
--- a/R/models_cache.R
+++ b/R/models_cache.R
@@ -354,18 +354,17 @@
   ent <- .cache_get(provider, base_url)
   if (is.null(ent)) {
     live <- .list_models_cached(provider, base_url)
-    mods_df <- live$df
+    mods <- live$df
     ts <- .cache_get(provider, base_url)$ts %||% as.numeric(Sys.time())
     src <- "live"
-    if (provider == "ollama" && nrow(mods_df) == 0) {
-      mods_vec <- .ollama_tags_live(base_url)
-      .cache_put(provider, base_url, mods_vec)
+    if (provider == "ollama" && nrow(mods) == 0) {
+      mods <- .ollama_tags_live(base_url)
+      .cache_put(provider, base_url, mods)
       ts <- .cache_get(provider, base_url)$ts
-      mods_df <- .as_models_df(mods_vec)
     }
-    .row_df(provider, base_url, mods_df, "installed", src, ts, status = live$status)
+    .row_df(provider, base_url, mods, "installed", src, ts, status = live$status)
   } else {
-    .row_df(provider, base_url, .as_models_df(ent$models), "installed", "cache", ent$ts)
+    .row_df(provider, base_url, ent$models, "installed", "cache", ent$ts)
   }
 }
 


### PR DESCRIPTION
## Summary
- Drop redundant `.as_models_df()` calls in `fetch_local_models_cached()` and let `.row_df()` handle normalization
- Pass cached model data to `.row_df()` untouched, trimming cache-hit path redundancy

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b7694b108c8321ac3f168ffe49cbbb