### PR TITLE
refactor: call openai live fetch directly

### DIFF
--- a/R/models_cache.R
+++ b/R/models_cache.R
@@ -373,7 +373,7 @@
                                         base_url = "https://api.openai.com") {
   ent <- .cache_get("openai", base_url)
   if (is.null(ent)) {
-    live <- .fetch_models_live("openai", base_url, openai_api_key)
+    live <- .fetch_models_live_openai(base_url, openai_api_key)
     if (identical(live$status, "ok") && nrow(live$df) > 0) {
       .cache_put("openai", base_url, live$df)
       ts <- .cache_get("openai", base_url)$ts


### PR DESCRIPTION
## Summary
- call `.fetch_models_live_openai()` directly in `.fetch_openai_models_cached`

## Testing
- `R -q -e 'devtools::test()'` *(fails: R command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b76bc578e48321a76d8ba6fb2b5d0a