### PR TITLE
Use cache_del for cache invalidation

### DIFF
--- a/R/models_cache.R
+++ b/R/models_cache.R
@@ -509,7 +509,7 @@ delete_models_cache <- function(provider = NULL, base_url = NULL) {
         for (k in keys) {
             ent <- .gptr_cache$get(k, missing = NULL)
             if (!is.null(ent) && identical(ent$provider, provider)) {
-                .gptr_cache$remove(k)
+                .cache_del(ent$provider, ent$base_url)
             }
         }
         return(invisible(TRUE))
@@ -521,14 +521,14 @@ delete_models_cache <- function(provider = NULL, base_url = NULL) {
         for (k in keys) {
             ent <- .gptr_cache$get(k, missing = NULL)
             if (!is.null(ent) && identical(ent$base_url, root)) {
-                .gptr_cache$remove(k)
+                .cache_del(ent$provider, ent$base_url)
             }
         }
         return(invisible(TRUE))
     }
 
     # both provider and base_url
-    .gptr_cache$remove(.cache_key(provider, base_url))
+    .cache_del(provider, base_url)
     invisible(TRUE)
 }
 

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -492,9 +492,19 @@ test_that("delete_models_cache removes by provider", {
             list(provider = "openai", base_url = "https://api.openai.com", models = list(), ts = 1))
   cache$set(key_fun("lmstudio", "http://127.0.0.1:1234"),
             list(provider = "lmstudio", base_url = "http://127.0.0.1:1234", models = list(), ts = 1))
+  calls <- list()
+  testthat::local_mocked_bindings(
+    .cache_del = function(p, u) {
+      calls <<- append(calls, list(c(p, u)))
+      cache$remove(key_fun(p, u))
+      invisible(TRUE)
+    },
+    .env = asNamespace("gptr")
+  )
   inv(provider = "openai")
   expect_null(cache$get(key_fun("openai", "https://api.openai.com"), missing = NULL))
   expect_false(is.null(cache$get(key_fun("lmstudio", "http://127.0.0.1:1234"), missing = NULL)))
+  expect_identical(calls, list(c("openai", "https://api.openai.com")))
 })
 
 test_that("delete_models_cache removes by base_url", {
@@ -506,9 +516,19 @@ test_that("delete_models_cache removes by base_url", {
             list(provider = "openai", base_url = "https://api.openai.com", models = list(), ts = 1))
   cache$set(key_fun("openai", "https://alt.openai.com"),
             list(provider = "openai", base_url = "https://alt.openai.com", models = list(), ts = 1))
+  calls <- list()
+  testthat::local_mocked_bindings(
+    .cache_del = function(p, u) {
+      calls <<- append(calls, list(c(p, u)))
+      cache$remove(key_fun(p, u))
+      invisible(TRUE)
+    },
+    .env = asNamespace("gptr")
+  )
   inv(base_url = "https://api.openai.com")
   expect_null(cache$get(key_fun("openai", "https://api.openai.com"), missing = NULL))
   expect_false(is.null(cache$get(key_fun("openai", "https://alt.openai.com"), missing = NULL)))
+  expect_identical(calls, list(c("openai", "https://api.openai.com")))
 })
 
 test_that("delete_models_cache removes by provider and base_url", {
@@ -520,9 +540,19 @@ test_that("delete_models_cache removes by provider and base_url", {
             list(provider = "openai", base_url = "https://api.openai.com", models = list(), ts = 1))
   cache$set(key_fun("openai", "https://alt.openai.com"),
             list(provider = "openai", base_url = "https://alt.openai.com", models = list(), ts = 1))
+  calls <- list()
+  testthat::local_mocked_bindings(
+    .cache_del = function(p, u) {
+      calls <<- append(calls, list(c(p, u)))
+      cache$remove(key_fun(p, u))
+      invisible(TRUE)
+    },
+    .env = asNamespace("gptr")
+  )
   inv(provider = "openai", base_url = "https://api.openai.com")
   expect_null(cache$get(key_fun("openai", "https://api.openai.com"), missing = NULL))
   expect_false(is.null(cache$get(key_fun("openai", "https://alt.openai.com"), missing = NULL)))
+  expect_identical(calls, list(c("openai", "https://api.openai.com")))
 })
 
 


### PR DESCRIPTION
## Summary
- Route all model cache deletions through `.cache_del` to centralize key handling.
- Delegate provider/base_url-specific cache invalidation to `.cache_del` and add tests verifying invocation.

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b76b90cae08321afa94a0fe8e9134d