### PR TITLE
Refactor model cache fetch naming

### DIFF
--- a/R/models_cache.R
+++ b/R/models_cache.R
@@ -350,7 +350,7 @@
     live
 }
 #' @keywords internal
-.fetch_local_models_cached <- function(provider, base_url) {
+.fetch_models_cached_local <- function(provider, base_url) {
   ent <- .cache_get(provider, base_url)
   if (is.null(ent)) {
     live <- .list_models_cached(provider, base_url)
@@ -369,7 +369,7 @@
 }
 
 #' @keywords internal
-.fetch_openai_models_cached <- function(openai_api_key,
+.fetch_models_cached_openai <- function(openai_api_key,
                                         base_url = "https://api.openai.com") {
   ent <- .cache_get("openai", base_url)
   if (is.null(ent)) {
@@ -432,11 +432,11 @@ list_models <- function(provider = NULL,
       )
       bu <- .api_root(base_url %||% bu_default)
       if (isTRUE(refresh)) .cache_del(p, bu)
-      rows[[length(rows) + 1L]] <- .fetch_local_models_cached(p, bu)
+      rows[[length(rows) + 1L]] <- .fetch_models_cached_local(p, bu)
     } else if (p == "openai") {
       bu <- .api_root(base_url %||% "https://api.openai.com")
       if (isTRUE(refresh)) .cache_del("openai", bu)
-      rows[[length(rows) + 1L]] <- .fetch_openai_models_cached(openai_api_key, bu)
+      rows[[length(rows) + 1L]] <- .fetch_models_cached_openai(openai_api_key, bu)
     }
   }
 

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -576,3 +576,11 @@ test_that("list_models - second call uses cache when available", {
 
 
 
+
+test_that(".fetch_models_cached_* helpers are present", {
+  f_local <- getFromNamespace(".fetch_models_cached_local", "gptr")
+  f_openai <- getFromNamespace(".fetch_models_cached_openai", "gptr")
+  expect_type(f_local, "closure")
+  expect_type(f_openai, "closure")
+})
+


### PR DESCRIPTION
## Summary
- rename cached model fetch helpers for consistent naming
- ensure `list_models()` uses new helper names
- cover renamed helpers with a unit test

## Testing
- `R -q -e "devtools::test()"` *(failed: command not found: R)*
- `apt-get update` *(failed: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b76bcf69e883219853b686e143f756