### PR TITLE
Remove OpenAI empty catalog delay and document status

### DIFF
--- a/R/models_cache.R
+++ b/R/models_cache.R
@@ -419,7 +419,6 @@
     } else if (identical(live$status, "ok") && nrow(live$df) == 0) {
       live$status <- "empty_cache"
       ts <- as.numeric(Sys.time())
-      Sys.sleep(0.25)
     } else {
       ts <- as.numeric(Sys.time())
     }
@@ -441,7 +440,9 @@
 #'     * "installed" for local backends
 #'     * "catalog"   for OpenAI (account/catalog listing)
 #' - Stable columns: provider, base_url, model_id, availability, cached_when, source.
-#'
+#' - If OpenAI returns no models, a placeholder row is still returned with
+#'   `status = "empty_cache"` and `model_id = NA`.
+#' 
 #' @param provider NULL (default, list all), or one of:
 #'   "lmstudio","ollama","localai","openai".
 #' @param base_url Optional root URL to target a specific server. If NULL,

--- a/man/list_models.Rd
+++ b/man/list_models.Rd
@@ -41,5 +41,7 @@ to force a live probe of \verb{/v1/models} (Ollama falls back to \verb{/api/tags
 \item "catalog"   for OpenAI (account/catalog listing)
 }
 \item Stable columns: provider, base_url, model_id, availability, cached_when, source.
+\item If OpenAI returns no models, a placeholder row is included with
+\code{status = "empty_cache"} and \code{model_id = NA}.
 }
 }

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -259,7 +259,9 @@ test_that("openai empty model list -> empty_cache", {
   payload <- list(data = list())
   mock_http_openai(status = 200L, json = payload)
   out <- list_models(provider = "openai", refresh = TRUE, openai_api_key = "sk-test")
-  expect_identical(nrow(out), 0L)
+  expect_identical(nrow(out), 1L)
+  expect_true(is.na(out$model_id))
+  expect_identical(out$status, "empty_cache")
 })
 
 test_that("openai fallback semantics via .fetch_models_live", {


### PR DESCRIPTION
## Summary
- Avoid artificial delay when OpenAI catalog request returns no models
- Document the `empty_cache` placeholder row in list_models output
- Update tests to assert the `empty_cache` status

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b771cd0d1c83218425ff343ad352c7