### PR TITLE
Remove openai_api_key argument from .fetch_models_live

### DIFF
--- a/R/models_cache.R
+++ b/R/models_cache.R
@@ -169,13 +169,13 @@
 #' @keywords internal
 .fetch_models_live <- function(provider,
                                base_url,
-                               openai_api_key = "",
                                timeout = getOption("gptr.request_timeout", 5)) {
   if (!requireNamespace("httr2", quietly = TRUE)) {
     return(list(df = data.frame(id = character(0), created = numeric(0)), status = "httr2_missing"))
   }
   if (identical(provider, "openai")) {
-    .fetch_models_live_openai(base_url, openai_api_key, timeout)
+    key <- Sys.getenv("OPENAI_API_KEY", "")
+    .fetch_models_live_openai(base_url, key, timeout)
   } else {
     .fetch_models_live_local(provider, base_url, timeout)
   }
@@ -337,10 +337,10 @@
         ttl <- getOption("gptr.model_cache_ttl", 3600)
         if (!is.na(ent$ts) && (as.numeric(Sys.time()) - ent$ts) < ttl) return(list(df = .as_models_df(ent$models), status = "ok"))
     }
-    live <- .fetch_models_live(provider, base_url, openai_api_key)
+    live <- .fetch_models_live(provider, base_url)
     if (identical(live$status, "unreachable")) {
         Sys.sleep(0.2)
-        live <- .fetch_models_live(provider, base_url, openai_api_key)
+        live <- .fetch_models_live(provider, base_url)
         if (identical(live$status, "unreachable")) {
             return(live)
         }

--- a/man/dot-fetch_models_live.Rd
+++ b/man/dot-fetch_models_live.Rd
@@ -10,7 +10,6 @@ a generic flow for local backends. Always uses the \verb{.http_*} wrappers.}
 .fetch_models_live(
   provider,
   base_url,
-  openai_api_key = "",
   timeout = getOption("gptr.request_timeout", 5)
 )
 }

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -219,37 +219,37 @@ test_that("refresh with no models returns empty data", {
 
 test_that("openai non-JSON -> non_json", {
   f <- getFromNamespace(".fetch_models_live", "gptr")
-  live <- function(key) f("openai", "https://api.openai.com", key)
+  withr::local_envvar(OPENAI_API_KEY = "sk-test")
   mock_http_openai(status = 200L, json_throws = TRUE)
-  o <- live("sk-test")
+  o <- f("openai", "https://api.openai.com")
   expect_equal(o$status, "non_json")
 })
 
 test_that("openai network error -> unreachable", {
   f <- getFromNamespace(".fetch_models_live", "gptr")
-  live <- function(key) f("openai", "https://api.openai.com", key)
+  withr::local_envvar(OPENAI_API_KEY = "sk-test")
   mock_http_openai(perform_throws = TRUE)
-  o <- live("sk-test")
+  o <- f("openai", "https://api.openai.com")
   expect_equal(o$status, "unreachable")
 })
 
 test_that("openai 5xx -> http_503", {
   f <- getFromNamespace(".fetch_models_live", "gptr")
-  live <- function(key) f("openai", "https://api.openai.com", key)
+  withr::local_envvar(OPENAI_API_KEY = "sk-test")
   mock_http_openai(status = 503L)
-  o <- live("sk-test")
+  o <- f("openai", "https://api.openai.com")
   expect_equal(o$status, "http_503")
 })
 
 test_that("openai ok -> df parsed and status ok", {
   f <- getFromNamespace(".fetch_models_live", "gptr")
-  live <- function(key) f("openai", "https://api.openai.com", key)
+  withr::local_envvar(OPENAI_API_KEY = "sk-test")
   payload <- list(data = list(
     list(id = "gpt-4o", created = 1683758102),
     list(id = "gpt-4.1-mini", created = 1686558896)
   ))
   mock_http_openai(status = 200L, json = payload)
-  o <- live("sk-test")
+  o <- f("openai", "https://api.openai.com")
   expect_equal(o$status, "ok")
   expect_true(is.data.frame(o$df))
   expect_setequal(o$df$id, c("gpt-4o", "gpt-4.1-mini"))
@@ -264,18 +264,18 @@ test_that("openai empty model list -> empty_cache", {
 
 test_that("openai fallback semantics via .fetch_models_live", {
   f <- getFromNamespace(".fetch_models_live", "gptr")
-  live <- function(key) f("openai", "https://api.openai.com", key)
+  withr::local_envvar(OPENAI_API_KEY = "sk")
 
   mock_http_openai(status = 200L, json_throws = TRUE)
-  o1 <- live("sk")
+  o1 <- f("openai", "https://api.openai.com")
   expect_equal(o1$status, "non_json")
 
   mock_http_openai(perform_throws = TRUE)
-  o2 <- live("sk")
+  o2 <- f("openai", "https://api.openai.com")
   expect_equal(o2$status, "unreachable")
 
   mock_http_openai(status = 503L)
-  o3 <- live("sk")
+  o3 <- f("openai", "https://api.openai.com")
   expect_equal(o3$status, "http_503")
 })
 


### PR DESCRIPTION
## Summary
- Remove `openai_api_key` parameter from `.fetch_models_live` and read key from `OPENAI_API_KEY` env var
- Update internal cache logic to call `.fetch_models_live` without API key
- Adjust tests to set `OPENAI_API_KEY` when probing `.fetch_models_live`

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: R command not found)*
- `apt-get install -y r-base` *(fails: package not found / repository errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b7721e76548321b82209ca343b856b