### PR TITLE
Return NULL for missing cache entries

### DIFF
--- a/R/models_cache.R
+++ b/R/models_cache.R
@@ -221,7 +221,8 @@
 }
 
 # Look up a cached entry in .gptr_cache by provider+base_url.
-# Returns NULL if not cached.
+# cachem's default `missing` value yields a `key_missing` sentinel; explicitly
+# return `NULL` when an entry doesn't exist so callers can rely on `is.null()`.
 .cache_get <- function(provider, base_url) {
   .gptr_cache$get(.cache_key(provider, base_url), missing = NULL)
 }

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -65,7 +65,7 @@ mock_http_openai <- function(status = 200L,
       base_url <- .cache_root_for_test(as.character(a[[2L]]))
       key <- key_fun(provider, base_url)
     }
-    .gptr_test_cache_store$get(key)
+    .gptr_test_cache_store$get(key, missing = NULL)
   },
   .cache_put = function(...) {
     a <- list(...)


### PR DESCRIPTION
## Summary
- Ensure `.cache_get()` explicitly returns `NULL` when cache key is absent, avoiding `key_missing` sentinel
- Align tests with new semantics by using `missing = NULL` in mocked cache

## Testing
- ❌ `R -q -e "devtools::test()"` *(R not installed; attempted installation but `apt-get update` failed with 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b77229971c83219bec907dd2f0a10b