### PR TITLE
refactor: mock httr2 network call without with_mocked_bindings

### DIFF
--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -113,22 +113,22 @@ test_that("auto + unknown model falls back to first preferred local", {
 
     delete_models_cache()
     called <- character()
-    httr2::with_mocked_bindings(
-        req_perform = function(req, ...) {
+    testthat::local_mock(
+        `httr2::req_perform` = function(req, ...) {
             url <- httr2::req_url(req)
             called <<- c(called, url)
             structure(list(url = url), class = "fake_resp")
         },
-        resp_status = function(resp) 404L,
-        resp_body_json = function(resp, ...) {
-            list(model = "fallback",
-                 choices = list(list(message = list(content = "ok"))))
-        },
-        {
-            res <- gpt("hi", model = "nonexistent-model", provider = "auto", print_raw = FALSE)
-            expect_true(grepl("^http://127\\.0\\.0\\.1:1234", tail(called, 1)))
+        `httr2::resp_status` = function(resp, ...) 404L,
+        `httr2::resp_body_json` = function(resp, ...) {
+            list(
+                model = "fallback",
+                choices = list(list(message = list(content = "ok")))
+            )
         }
     )
+    res <- gpt("hi", model = "nonexistent-model", provider = "auto", print_raw = FALSE)
+    expect_true(grepl("^http://127\\.0\\.0\\.1:1234", tail(called, 1)))
 })
 
 test_that("auto with no local backend falls back to OpenAI", {


### PR DESCRIPTION
## Summary
- replace deprecated `httr2::with_mocked_bindings()` with `testthat::local_mock()` in backend fallback test
- ensure mocked httr2 functions exercise local fallback path without real HTTP requests

## Testing
- `Rscript -e "testthat::test_file('tests/testthat/test-backends.R', filter='unknown model falls back')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7722eea3c8321be90e34b3723f857