### PR TITLE
Rename cached models helper

### DIFF
--- a/R/gpt.R
+++ b/R/gpt.R
@@ -86,8 +86,8 @@ gpt <- function(prompt,
         } else {
             picked <- FALSE
             for (bk in prefer) {
-                lm <- try(.list_models_cached(provider = bk, base_url = roots[[bk]],
-                                              openai_api_key = openai_api_key), silent = TRUE)
+                lm <- try(.fetch_models_cached(provider = bk, base_url = roots[[bk]],
+                                                   openai_api_key = openai_api_key), silent = TRUE)
                 if (!inherits(lm, "try-error") && is.list(lm) && NROW(lm$df)) {
                     base_root <- .api_root(roots[[bk]])
                     backend   <- bk
@@ -168,13 +168,13 @@ gpt <- function(prompt,
         defs <- .resolve_openai_defaults(model = model, base_url = base_url, api_key = openai_api_key)
         bu_root <- .api_root(defs$base_url)
         if (is.null(.cache_get("openai", bu_root))) {
-            invisible(try(.list_models_cached(provider = "openai", base_url = bu_root,
-                                             openai_api_key = defs$api_key), silent = TRUE))
+            invisible(try(.fetch_models_cached(provider = "openai", base_url = bu_root,
+                                                  openai_api_key = defs$api_key), silent = TRUE))
         }
         if (!is.null(model) && nzchar(model)) {
             ids <- tryCatch(
-                .list_models_cached(provider = "openai", base_url = bu_root,
-                                    openai_api_key = defs$api_key)$df$id,
+                .fetch_models_cached(provider = "openai", base_url = bu_root,
+                                         openai_api_key = defs$api_key)$df$id,
                 error = function(e) character(0)
             )
             if (length(ids) && !tolower(model) %in% tolower(ids)) {
@@ -197,8 +197,8 @@ gpt <- function(prompt,
     if (provider == "local") {
         stopifnot(!is.null(base_root), nzchar(base_root))
 
-        ent <- try(.list_models_cached(provider = backend, base_url = base_root,
-                                       openai_api_key = openai_api_key), silent = TRUE)
+        ent <- try(.fetch_models_cached(provider = backend, base_url = base_root,
+                                           openai_api_key = openai_api_key), silent = TRUE)
         ids <- if (!inherits(ent, "try-error") && is.list(ent) && !is.null(ent$df)) {
             unique(na.omit(as.character(ent$df$id)))
         } else character(0)

--- a/R/models_cache.R
+++ b/R/models_cache.R
@@ -258,8 +258,8 @@
 
 #' @noRd
 #' @keywords internal
-.list_models_cached <- function(provider = NULL, base_url = NULL,
-                               openai_api_key = Sys.getenv("OPENAI_API_KEY", "")) {
+.fetch_models_cached <- function(provider = NULL, base_url = NULL,
+                                    openai_api_key = Sys.getenv("OPENAI_API_KEY", "")) {
     # Case A: both missing -> enumerate everything currently cached (summary view)
     if (is.null(provider) && is.null(base_url)) {
         keys <- .gptr_cache$keys()
@@ -369,8 +369,8 @@
             localai  = getOption("gptr.localai_base_url",  "http://127.0.0.1:8080"),
             openai   = "https://api.openai.com"
         )
-        ent <- try(.list_models_cached(provider = p, base_url = bu,
-                                       openai_api_key = openai_api_key), silent = TRUE)
+        ent <- try(.fetch_models_cached(provider = p, base_url = bu,
+                                            openai_api_key = openai_api_key), silent = TRUE)
         ids <- tryCatch({
             if (is.list(ent) && !is.null(ent$df)) as.character(ent$df$id) else character(0)
         }, error = function(e) character(0))
@@ -392,7 +392,7 @@
 .fetch_models_cached_local <- function(provider, base_url) {
   ent <- .cache_get(provider, base_url)
   if (is.null(ent)) {
-    live <- .list_models_cached(provider, base_url)
+    live <- .fetch_models_cached(provider, base_url)
     mods <- live$df
     ts <- .cache_get(provider, base_url)$ts %||% as.numeric(Sys.time())
     src <- "live"

--- a/dev/structure/internals.txt
+++ b/dev/structure/internals.txt
@@ -30,7 +30,7 @@ $.gpt_chat_callable
 .is_na_like
 .json_last_resort
 .list_local_backends
-.list_models_cached
+.fetch_models_cached
 .fetch_models_live
 .models_endpoint
 .normalize_token

--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -20,8 +20,8 @@ test_that("auto + openai model routes to OpenAI", {
                 stringsAsFactors = FALSE
             )
         },
-        .list_models_cached = function(provider = NULL, base_url = NULL,
-                                       openai_api_key = "", ...) {
+        .fetch_models_cached = function(provider = NULL, base_url = NULL,
+                                            openai_api_key = "", ...) {
             list(df = data.frame(id = "gpt-4o-mini", stringsAsFactors = FALSE),
                  status = "ok")
         },
@@ -52,8 +52,8 @@ test_that("auto + local model routes to local", {
                 stringsAsFactors = FALSE
             )
         },
-        .list_models_cached = function(provider = NULL, base_url = NULL,
-                                       openai_api_key = "", ...) {
+        .fetch_models_cached = function(provider = NULL, base_url = NULL,
+                                            openai_api_key = "", ...) {
             list(df = data.frame(id = "mistralai/mistral-7b-instruct-v0.3",
                                  stringsAsFactors = FALSE), status = "ok")
         },
@@ -88,8 +88,8 @@ test_that("auto + duplicate model prefers locals via gptr.local_prefer", {
                 stringsAsFactors = FALSE
             )
         },
-        .list_models_cached = function(provider = NULL, base_url = NULL,
-                                       openai_api_key = "", ...) {
+        .fetch_models_cached = function(provider = NULL, base_url = NULL,
+                                            openai_api_key = "", ...) {
             list(df = data.frame(id = "o1-mini", stringsAsFactors = FALSE), status = "ok")
         },
         request_local = function(payload, base_url, timeout = 30) {
@@ -138,8 +138,8 @@ test_that("auto with no local backend falls back to OpenAI", {
             data.frame(provider = character(), base_url = character(),
                        model_id = character(), stringsAsFactors = FALSE)
         },
-        .list_models_cached = function(provider = NULL, base_url = NULL,
-                                       openai_api_key = "", ...) {
+        .fetch_models_cached = function(provider = NULL, base_url = NULL,
+                                            openai_api_key = "", ...) {
             list(df = data.frame(id = character(), stringsAsFactors = FALSE), status = "ok")
         },
         request_openai = function(payload, base_url, api_key, timeout = 30) {
@@ -160,8 +160,8 @@ test_that("auto with no local backend falls back to OpenAI", {
 test_that("provider=openai routes to OpenAI even if locals have models", {
     called <- NULL
     with_mocked_bindings(
-        .list_models_cached = function(provider = NULL, base_url = NULL,
-                                       openai_api_key = "", ...) {
+        .fetch_models_cached = function(provider = NULL, base_url = NULL,
+                                            openai_api_key = "", ...) {
             list(df = data.frame(id = "gpt-4o-mini", stringsAsFactors = FALSE),
                  status = "ok")
         },
@@ -182,8 +182,8 @@ test_that("provider=openai routes to OpenAI even if locals have models", {
 test_that("explicit local base_url is honored", {
     called <- NULL
     with_mocked_bindings(
-        .list_models_cached = function(provider = NULL, base_url = NULL,
-                                       openai_api_key = "", ...) {
+        .fetch_models_cached = function(provider = NULL, base_url = NULL,
+                                            openai_api_key = "", ...) {
             list(df = data.frame(id = "mistralai/mistral-7b-instruct-v0.3",
                                  stringsAsFactors = FALSE), status = "ok")
         },
@@ -205,8 +205,8 @@ test_that("explicit local base_url is honored", {
 
 test_that("strict_model errors when model not installed (local)", {
     with_mocked_bindings(
-        .list_models_cached = function(provider = NULL, base_url = NULL,
-                                       openai_api_key = "", ...) {
+        .fetch_models_cached = function(provider = NULL, base_url = NULL,
+                                            openai_api_key = "", ...) {
             list(df = data.frame(id = "mistral", stringsAsFactors = FALSE), status = "ok")
         },
         request_local = function(payload, base_url, timeout = 30) {
@@ -227,8 +227,8 @@ test_that("strict_model errors when model not installed (local)", {
 
 test_that("strict_model ignored when model listing unavailable", {
     with_mocked_bindings(
-        .list_models_cached = function(provider = NULL, base_url = NULL,
-                                       openai_api_key = "", ...) {
+        .fetch_models_cached = function(provider = NULL, base_url = NULL,
+                                            openai_api_key = "", ...) {
             list(df = data.frame(id = character(), stringsAsFactors = FALSE), status = "ok")
         },
         request_local = function(payload, base_url, timeout = 30) {
@@ -258,8 +258,8 @@ test_that("model match is case-insensitive", {
                 stringsAsFactors = FALSE
             )
         },
-        .list_models_cached = function(provider = NULL, base_url = NULL,
-                                       openai_api_key = "", ...) {
+        .fetch_models_cached = function(provider = NULL, base_url = NULL,
+                                            openai_api_key = "", ...) {
             list(df = data.frame(id = "GPT-4O-MINI", stringsAsFactors = FALSE), status = "ok")
         },
         request_openai = function(payload, base_url, api_key, timeout = 30) {

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -343,12 +343,12 @@ test_that("refresh_models retries after unreachable and caches", {
   expect_identical(cached$models$id, "m1")
 })
 
-test_that(".list_models_cached skips cache when unreachable", {
+test_that(".fetch_models_cached skips cache when unreachable", {
   fake_cache <- make_fake_cache()
   live_mock <- function(provider, base_url) {
     list(df = data.frame(id = character(), created = numeric()), status = "unreachable")
   }
-  f <- getFromNamespace(".list_models_cached", "gptr")
+  f <- getFromNamespace(".fetch_models_cached", "gptr")
   testthat::local_mocked_bindings(
     .fetch_models_live = live_mock,
     .cache_get = function(p, u) fake_cache$get(p, u),
@@ -361,7 +361,7 @@ test_that(".list_models_cached skips cache when unreachable", {
   expect_null(fake_cache$get("lmstudio", "http://127.0.0.1:1234"))
 })
 
-test_that(".list_models_cached retries after unreachable and caches", {
+test_that(".fetch_models_cached retries after unreachable and caches", {
   fake_cache <- make_fake_cache()
   calls <- 0
   live_mock <- function(provider, base_url) {
@@ -372,7 +372,7 @@ test_that(".list_models_cached retries after unreachable and caches", {
       list(df = data.frame(id = "m1", created = 1), status = "ok")
     }
   }
-  f <- getFromNamespace(".list_models_cached", "gptr")
+  f <- getFromNamespace(".fetch_models_cached", "gptr")
   testthat::local_mocked_bindings(
     .fetch_models_live = live_mock,
     .cache_get = function(p, u) fake_cache$get(p, u),
@@ -456,8 +456,8 @@ test_that(".row_df preserves status when no models", {
 })
 
 
-test_that(".list_models_cached enumerates cache contents", {
-  f <- getFromNamespace(".list_models_cached", "gptr")
+test_that(".fetch_models_cached enumerates cache contents", {
+  f <- getFromNamespace(".fetch_models_cached", "gptr")
   cache <- getFromNamespace(".gptr_cache", "gptr")
   key_fun <- getFromNamespace(".cache_key", "gptr")
   cache$reset()


### PR DESCRIPTION
## Summary
- Rename `.fetch_models_cached_raw` helper to `.fetch_models_cached`
- Update GPT interface and caching utilities to use renamed helper
- Adjust tests and docs to reflect new helper name

## Testing
- ❌ `R -q -e "testthat::test_dir('tests/testthat')"` (command not found: R)
- ⚠️ `apt-get update` (403 Forbidden fetching packages)


------
https://chatgpt.com/codex/tasks/task_e_68b771b7490c8321aa73dd5dbf058c08