### PR TITLE
Remove openai_api_key argument from .fetch_models_live

### DIFF
--- a/man/dot-fetch_models_live.Rd
+++ b/man/dot-fetch_models_live.Rd
@@ -10,6 +10,7 @@ a generic flow for local backends. Always uses the \verb{.http_*} wrappers.}
 .fetch_models_live(
   provider,
   base_url,
+  openai_api_key = Sys.getenv("OPENAI_API_KEY", unset = NA),
   timeout = getOption("gptr.request_timeout", 5)
 )
 }

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -300,7 +300,7 @@ test_that("refresh_models handles openai provider", {
 
 test_that("refresh_models skips cache when unreachable", {
   fake_cache <- make_fake_cache()
-  live_mock <- function(provider, base_url) {
+  live_mock <- function(provider, base_url, openai_api_key = "") {
     list(df = data.frame(id = character(), created = numeric()), status = "unreachable")
   }
   testthat::local_mocked_bindings(
@@ -320,7 +320,7 @@ test_that("refresh_models skips cache when unreachable", {
 test_that("refresh_models retries after unreachable and caches", {
   fake_cache <- make_fake_cache()
   calls <- 0
-  live_mock <- function(provider, base_url) {
+  live_mock <- function(provider, base_url, openai_api_key = "") {
     calls <<- calls + 1
     if (calls == 1) {
       list(df = data.frame(id = character(), created = numeric()), status = "unreachable")
@@ -345,7 +345,7 @@ test_that("refresh_models retries after unreachable and caches", {
 
 test_that(".list_models_cached skips cache when unreachable", {
   fake_cache <- make_fake_cache()
-  live_mock <- function(provider, base_url) {
+  live_mock <- function(provider, base_url, openai_api_key = "") {
     list(df = data.frame(id = character(), created = numeric()), status = "unreachable")
   }
   f <- getFromNamespace(".list_models_cached", "gptr")
@@ -364,7 +364,7 @@ test_that(".list_models_cached skips cache when unreachable", {
 test_that(".list_models_cached retries after unreachable and caches", {
   fake_cache <- make_fake_cache()
   calls <- 0
-  live_mock <- function(provider, base_url) {
+  live_mock <- function(provider, base_url, openai_api_key = "") {
     calls <<- calls + 1
     if (calls == 1) {
       list(df = data.frame(id = character(), created = numeric()), status = "unreachable")


### PR DESCRIPTION
## Summary
- Reintroduce optional `openai_api_key` parameter in `.fetch_models_live` with environment fallback
- Forward API key through `.list_models_cached` to preserve caller-provided keys
- Update tests to handle new `.fetch_models_live` signature

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y r-base` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b807430ff48321a3af965b1ec4f2c3