### PR TITLE
Avoid caching empty model listings

### DIFF
--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -214,6 +214,7 @@ test_that("refresh with no models returns empty data", {
   )
   out <- list_models(provider = "lmstudio", refresh = TRUE)
   expect_equal(nrow(out), 0)
+  expect_length(fake_cache$cache$keys(), 0)
 })
 
 


### PR DESCRIPTION
## Summary
- Prevent caching when backend returns no models and clear any existing entry
- Ensure local model fetches return zero rows without status when empty
- Add regression test for refresh with empty model list

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*
- `apt-get update` *(fails: repository '... InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8372af6888321be1d307a5164548e