### PR TITLE
Handle empty model listings without placeholder rows

### DIFF
--- a/R/utils-cache.R
+++ b/R/utils-cache.R
@@ -55,21 +55,9 @@
     base_url <- .api_root(base_url)
     models_df <- .as_models_df(models_df)
     ts <- if (length(ts)) ts else NA_real_  # coalesce: legacy cache entries may omit ts
+
     if (nrow(models_df) == 0) {
-        if (!is.na(status)) {
-            return(data.frame(
-                provider = provider,
-                base_url = base_url,
-                model_id = NA_character_,
-                created = NA_real_,
-                availability = availability,
-                cached_at = as.POSIXct(ts, origin = "1970-01-01", tz = "UTC"),
-                source = src,
-                status = status,
-                stringsAsFactors = FALSE
-            ))
-        }
-        return(data.frame(
+        df <- data.frame(
             provider = character(),
             base_url = character(),
             model_id = character(),
@@ -79,9 +67,12 @@
             source = character(),
             status = character(),
             stringsAsFactors = FALSE
-        ))
+        )
+        attr(df, "diagnostic") <- list(provider = provider, base_url = base_url, status = status)
+        return(df)
     }
-    data.frame(
+
+    df <- data.frame(
         provider = provider,
         base_url = base_url,
         model_id = models_df$id,
@@ -92,4 +83,6 @@
         status = status,
         stringsAsFactors = FALSE
     )
+    attr(df, "diagnostic") <- list(provider = provider, base_url = base_url, status = status)
+    df
 }

--- a/man/list_models.Rd
+++ b/man/list_models.Rd
@@ -27,7 +27,9 @@ an auth_missing status (no stop).}
 }
 \value{
 data.frame with columns:
-provider, base_url, model_id, availability, cached_when, source, and optional status.
+provider, base_url, model_id, availability, cached_when, source, and status. Status
+diagnostics for each backend are also provided via \code{attr(x, "diagnostics")}, a list of
+\code{provider}, \code{base_url}, and \code{status} entries.
 }
 \description{
 Behavior:
@@ -41,7 +43,7 @@ to force a live probe of \verb{/v1/models} (Ollama falls back to \verb{/api/tags
 \item "catalog"   for OpenAI (account/catalog listing)
 }
 \item Stable columns: provider, base_url, model_id, availability, cached_when, source.
-\item If OpenAI returns no models, a placeholder row is still returned with
-\code{status = "empty_cache"} and \code{model_id = NA}.
+\item If a backend returns no models, zero rows are returned; status is reported in
+\code{attr(x, "diagnostics")}.
 }
 }

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -259,9 +259,10 @@ test_that("openai empty model list -> empty_cache", {
   payload <- list(data = list())
   mock_http_openai(status = 200L, json = payload)
   out <- list_models(provider = "openai", refresh = TRUE, openai_api_key = "sk-test")
-  expect_identical(nrow(out), 1L)
-  expect_true(is.na(out$model_id))
-  expect_identical(out$status, "empty_cache")
+  expect_identical(nrow(out), 0L)
+  diag <- attr(out, "diagnostics")[[1]]
+  expect_identical(diag$status, "empty_cache")
+  expect_identical(diag$provider, "openai")
 })
 
 test_that("openai fallback semantics via .fetch_models_live", {
@@ -300,24 +301,25 @@ test_that("refresh_models handles openai provider", {
   expect_true(NROW(cached$models) == 2)
 })
 
-test_that("refresh_models skips cache when unreachable", {
-  fake_cache <- make_fake_cache()
-  live_mock <- function(provider, base_url) {
-    list(df = data.frame(id = character(), created = numeric()), status = "unreachable")
-  }
-  testthat::local_mocked_bindings(
-    .fetch_models_live = live_mock,
-    .cache_put = function(p, u, m) fake_cache$put(p, u, m),
-    .cache_get = function(p, u) fake_cache$get(p, u),
-    .cache_del = function(...) invisible(TRUE),
-    .env = asNamespace("gptr")
-  )
-  out <- refresh_models(provider = "lmstudio", base_url = "http://127.0.0.1:1234")
-  expect_identical(nrow(out), 1L)
-  expect_identical(out$status, "unreachable")
-  expect_true(all(is.na(out$model_id)))
-  expect_null(fake_cache$get("lmstudio", "http://127.0.0.1:1234"))
-})
+  test_that("refresh_models skips cache when unreachable", {
+    fake_cache <- make_fake_cache()
+    live_mock <- function(provider, base_url) {
+      list(df = data.frame(id = character(), created = numeric()), status = "unreachable")
+    }
+    testthat::local_mocked_bindings(
+      .fetch_models_live = live_mock,
+      .cache_put = function(p, u, m) fake_cache$put(p, u, m),
+      .cache_get = function(p, u) fake_cache$get(p, u),
+      .cache_del = function(...) invisible(TRUE),
+      .env = asNamespace("gptr")
+    )
+    out <- refresh_models(provider = "lmstudio", base_url = "http://127.0.0.1:1234")
+    expect_identical(nrow(out), 0L)
+    diag <- attr(out, "diagnostics")[[1]]
+    expect_identical(diag$status, "unreachable")
+    expect_identical(diag$provider, "lmstudio")
+    expect_null(fake_cache$get("lmstudio", "http://127.0.0.1:1234"))
+  })
 
 test_that("refresh_models retries after unreachable and caches", {
   fake_cache <- make_fake_cache()
@@ -439,6 +441,7 @@ test_that(".row_df repeats provider/base/url and status", {
   expect_equal(unique(r$provider), "openai")
   expect_equal(nrow(r), 2)
   expect_equal(r$status, rep("ok", 2))
+  expect_equal(attr(r, "diagnostic")$status, "ok")
 })
 
 test_that(".row_df returns zero rows when no models and status is NA", {
@@ -452,9 +455,10 @@ test_that(".row_df preserves status when no models", {
   f <- getFromNamespace(".row_df", "gptr")
   r <- f("openai", "https://api.openai.com", data.frame(id = character(), created = numeric()),
          "catalog", "live", fixed_ts, status = "auth_missing")
-  expect_equal(nrow(r), 1)
-  expect_true(is.na(r$model_id))
-  expect_equal(r$status, "auth_missing")
+  expect_equal(nrow(r), 0)
+  diag <- attr(r, "diagnostic")
+  expect_equal(diag$status, "auth_missing")
+  expect_equal(diag$provider, "openai")
 })
 
 


### PR DESCRIPTION
## Summary
- Avoid adding placeholder rows for empty model lists by `.row_df()`; status is now stored in a `diagnostic` attribute.
- `list_models()` gathers these diagnostics and attaches them as metadata for callers.
- Document zero-row contract and update tests to check diagnostic attributes.

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: command not found: R)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b841f22fec83219f4a5185336a1689