### PR TITLE
Refactor tests to use httr2 mocks

### DIFF
--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -45,7 +45,8 @@ mock_http_openai <- function(status = 200L,
     } else {
       function(resp, simplifyVector = FALSE) json
     },
-    .env = asNamespace("gptr")
+    .env = asNamespace("gptr"),
+    .local_envir = parent.frame()
   )
   invisible(TRUE)
 }


### PR DESCRIPTION
## Summary
- persist httr2 HTTP mocks for the duration of model cache tests by binding to the parent frame

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b860f01ab48321ae4ff20958666e8c