### PR TITLE
Fix OpenAI mock response body structure in tests

### DIFF
--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -1,16 +1,14 @@
 fake_resp <- function(model = "dummy") {
-    body <- jsonlite::toJSON(
-        list(
-            model = model,
-            choices = list(list(message = list(content = "ok")))
-        ),
-        auto_unbox = TRUE
+    body <- list(
+        model = model,
+        choices = list(list(message = list(content = "ok")))
     )
-    httr2::response(
+    resp <- httr2::response(
         status = 200L,
-        body = charToRaw(body),
+        body = charToRaw(jsonlite::toJSON(body, auto_unbox = TRUE)),
         headers = list("content-type" = "application/json")
     )
+    list(body = body, resp = resp)
 }
 
 test_that("auto + openai model routes to OpenAI", {


### PR DESCRIPTION
## Summary
- Return a list with `choices` and response when mocking OpenAI calls so `openai_parse_text()` receives a realistic structure

## Testing
- `R -q -e 'testthat::test_file("tests/testthat/test-backends.R")'` *(fails: command not found: R)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b257df588321aceb1ad638b807f9