### PR TITLE
Abort on missing auto models

### DIFF
--- a/R/gpt.R
+++ b/R/gpt.R
@@ -60,6 +60,8 @@ gpt <- function(prompt,
                 backend  <- hit_provider
                 base_root <- .api_root(as.character(hit$base_url[1L]))
             }
+        } else {
+            rlang::abort(sprintf("Model '%s' is not available; specify a provider.", model))
         }
     }
 

--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -132,7 +132,8 @@ test_that("auto + unknown model errors asking for provider", {
     )
     expect_error(
         gpt("hi", model = "nonexistent-model", provider = "auto", print_raw = FALSE),
-        "specify a provider"
+        "Model 'nonexistent-model' is not available; specify a provider.",
+        fixed = TRUE
     )
 })
 


### PR DESCRIPTION
## Summary
- Abort early when an auto provider is requested with a model that does not exist in any backend.
- Update backend tests to expect the new abort message.

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*
- `apt-get update && apt-get install -y r-base` *(fails: repository not signed / package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bc59384083219fa97df55add90a8