### PR TITLE
Abort when auto model provider missing

### DIFF
--- a/R/gpt.R
+++ b/R/gpt.R
@@ -43,7 +43,7 @@ gpt <- function(prompt,
     # --- Early auto+model resolution (use cache, no heuristics) ---
     if (identical(provider, "auto") && is.character(model) && nzchar(model)) {
         lm <- try(.resolve_model_provider(model, openai_api_key = openai_api_key), silent = TRUE)
-        if (!inherits(lm, "try-error") && NROW(lm)) {
+        if (!inherits(lm, "try-error") && is.data.frame(lm) && nrow(lm) > 0) {
             hits <- lm
             prefer_locals <- getOption("gptr.local_prefer", c("lmstudio","ollama","localai"))
             rank_fn <- function(p) {

--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -137,6 +137,20 @@ test_that("auto + unknown model errors asking for provider", {
     )
 })
 
+test_that("auto + model resolution returning NULL errors asking for provider", {
+    testthat::with_mocked_bindings(
+        .resolve_model_provider = function(model, openai_api_key = "", ...) NULL,
+        {
+            expect_error(
+                gpt("hi", model = "missing", provider = "auto", print_raw = FALSE),
+                "Model 'missing' is not available; specify a provider.",
+                fixed = TRUE
+            )
+        },
+        .env = asNamespace("gptr")
+    )
+})
+
 test_that("auto with no local backend falls back to OpenAI", {
     called <- NULL
     testthat::with_mocked_bindings(


### PR DESCRIPTION
## Summary
- Guard auto model resolution against non-data frame results and emit a clear error when no provider can satisfy the model.
- Test that auto mode aborts with guidance when `.resolve_model_provider()` returns no candidate.

## Testing
- `R -q -e "devtools::test()"` *(failed: command not found)*
- `apt-get update` *(failed: repositories not signed)*
- `apt-get install -y r-base` *(failed: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ca3d5cfc832189095bb9fcd2e4f9