### PR TITLE
Bypass strict model check when models list missing

### DIFF
--- a/R/gpt.R
+++ b/R/gpt.R
@@ -208,6 +208,8 @@ gpt <- function(prompt,
             unique(na.omit(as.character(ent$df$id)))
         } else character(0)
 
+        if (isTRUE(strict_model) && !length(ids)) strict_model <- FALSE
+
         default_model <- getOption("gptr.local_model", if (length(ids)) ids[[1]] else "mistralai/mistral-7b-instruct-v0.3")
         requested_model <- model %||% default_model
 

--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -270,10 +270,11 @@ test_that("strict_model errors when model not installed (local)", {
 
 test_that("strict_model ignored when model listing unavailable", {
     delete_models_cache()
-    called <- FALSE
+    called_models <- FALSE
+    called_chat <- FALSE
     testthat::local_mocked_bindings(
         req_perform = function(req, ...) {
-            called <<- TRUE
+            called_models <<- TRUE
             fake_resp()
         },
         resp_status = function(resp, ...) 404L,
@@ -281,7 +282,8 @@ test_that("strict_model ignored when model listing unavailable", {
     )
     testthat::local_mocked_bindings(
         request_local = function(payload, base_url, timeout = 30) {
-            fake_resp(model = payload$model %||% "mistral")
+            called_chat <<- TRUE
+            fake_resp(model = "fallback")
         },
         .env = asNamespace("gptr")
     )
@@ -293,7 +295,8 @@ test_that("strict_model ignored when model listing unavailable", {
             print_raw = FALSE),
         NA
     )
-    expect_true(called)
+    expect_true(called_models)
+    expect_true(called_chat)
 })
 
 test_that("model match is case-insensitive", {


### PR DESCRIPTION
## Summary
- Disable strict model enforcement when available models cannot be retrieved, allowing requests to proceed
- Test that requests still execute when model listing fails

## Testing
- ⚠️ `R -q -e 'testthat::test_dir("tests/testthat")'` *(missing: there is no package called 'testthat')*


------
https://chatgpt.com/codex/tasks/task_e_68b8d39275d883218e240c7f555fcaaf