### PR TITLE
Use testthat::test_path for exports fixture

### DIFF
--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,6 +1,9 @@
 test_that("exports.txt up to date", {
   cur <- sort(getNamespaceExports("gptr"))
-  exp <- readLines("dev/structure/exports.txt", warn = FALSE)
+  exp <- readLines(
+    testthat::test_path("..", "dev", "structure", "exports.txt"),
+    warn = FALSE
+  )
   expect_equal(cur, sort(exp), info = "Run /dev/structure/generate.R to update this file")
 
 })


### PR DESCRIPTION
## Summary
- use `testthat::test_path()` to locate `exports.txt`
- continue comparing sorted exports in tests

## Testing
- `R -q -e 'testthat::test_local()'` *(fails: there is no package called 'testthat')*
- `R -q -e 'install.packages("testthat", repos="https://cloud.r-project.org")'` *(fails: package 'testthat' is not available for this version of R)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d38f8f0c832195ac3c433a334f8c