### PR TITLE
validate model provider availability when auto resolving

### DIFF
--- a/R/gpt.R
+++ b/R/gpt.R
@@ -43,25 +43,27 @@ gpt <- function(prompt,
     # --- Early auto+model resolution (use cache, no heuristics) ---
     if (identical(provider, "auto") && is.character(model) && nzchar(model)) {
         lm <- try(.resolve_model_provider(model, openai_api_key = openai_api_key), silent = TRUE)
-        if (!inherits(lm, "try-error") && is.data.frame(lm) && nrow(lm) > 0) {
-            hits <- lm
-            prefer_locals <- getOption("gptr.local_prefer", c("lmstudio","ollama","localai"))
-            rank_fn <- function(p) {
-                m <- match(p, c(prefer_locals, "openai"))
-                ifelse(is.na(m), 999L, m)
-            }
-            ord <- order(rank_fn(tolower(as.character(hits$provider))))
-            hit <- hits[ord[1L], , drop = FALSE]
-            hit_provider <- tolower(as.character(hit$provider))
-            if (identical(hit_provider, "openai")) {
-                provider <- "openai"
-            } else {
-                provider <- "local"
-                backend  <- hit_provider
-                base_root <- .api_root(as.character(hit$base_url[1L]))
-            }
-        } else {
+        if (inherits(lm, "try-error") || !is.data.frame(lm)) {
             rlang::abort(sprintf("Model '%s' is not available; specify a provider.", model))
+        }
+        if (nrow(lm) == 0) {
+            rlang::abort(sprintf("Model '%s' is not available; specify a provider.", model))
+        }
+        hits <- lm
+        prefer_locals <- getOption("gptr.local_prefer", c("lmstudio","ollama","localai"))
+        rank_fn <- function(p) {
+            m <- match(p, c(prefer_locals, "openai"))
+            ifelse(is.na(m), 999L, m)
+        }
+        ord <- order(rank_fn(tolower(as.character(hits$provider))))
+        hit <- hits[ord[1L], , drop = FALSE]
+        hit_provider <- tolower(as.character(hit$provider))
+        if (identical(hit_provider, "openai")) {
+            provider <- "openai"
+        } else {
+            provider <- "local"
+            backend  <- hit_provider
+            base_root <- .api_root(as.character(hit$base_url[1L]))
         }
     }
 

--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -151,6 +151,23 @@ test_that("auto + model resolution returning NULL errors asking for provider", {
     )
 })
 
+test_that("auto + model resolution returning empty data frame errors asking for provider", {
+    testthat::with_mocked_bindings(
+        .resolve_model_provider = function(model, openai_api_key = "", ...) {
+            data.frame(provider = character(), base_url = character(),
+                       model_id = character(), stringsAsFactors = FALSE)
+        },
+        {
+            expect_error(
+                gpt("hi", model = "missing", provider = "auto", print_raw = FALSE),
+                "Model 'missing' is not available; specify a provider.",
+                fixed = TRUE
+            )
+        },
+        .env = asNamespace("gptr")
+    )
+})
+
 test_that("auto with no local backend falls back to OpenAI", {
     called <- NULL
     testthat::with_mocked_bindings(


### PR DESCRIPTION
## Summary
- abort early if `.resolve_model_provider()` returns no rows for a model when provider is `auto`
- cover empty data frame from `.resolve_model_provider()` with a unit test

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*
- `apt-get install -y r-base` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b95a0d8d588321a7e85824264fd1ee