### PR TITLE
Specify minimum httr2 version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Imports:
-    httr2,
+    httr2 (>= 1.0.0),
     tibble,
     dplyr,
     jsonlite,


### PR DESCRIPTION
## Summary
- require httr2 v1.0.0 or higher

## Testing
- `R -q -e "devtools::document()"` *(fails: bash: command not found: R)*
- `apt-get update` *(fails: repository not signed)*
- `R -q -e "devtools::test()"` *(fails: bash: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_68b962d8cffc83218670012835af429d