### PR TITLE
Avoid network requests for unknown auto model test

### DIFF
--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -130,11 +130,16 @@ test_that("auto + unknown model errors asking for provider", {
         },
         .env = asNamespace("gptr")
     )
+    testthat::local_mocked_bindings(
+        .resolve_model_provider = function(...) data.frame(),
+        .env = asNamespace("gptr")
+    )
     expect_error(
         gpt("hi", model = "nonexistent-model", provider = "auto", print_raw = FALSE),
         "Model 'nonexistent-model' is not available; specify a provider.",
         fixed = TRUE
     )
+    expect_identical(called, character())
 })
 
 test_that("auto + model resolution returning NULL errors asking for provider", {


### PR DESCRIPTION
## Summary
- Mock `.resolve_model_provider` in unknown-model test to return an empty data frame
- Assert no HTTP requests occur when auto provider cannot resolve model

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b96ad4ad808321878824bafe1f17f7