### PR TITLE
Use local mocked bindings in backend tests

### DIFF
--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -11,9 +11,12 @@ fake_resp <- function(model = "dummy") {
     list(body = body, resp = resp)
 }
 
+original_resolve_model_provider <- gptr:::.resolve_model_provider
+original_fetch_models_cached <- gptr:::.fetch_models_cached
+
 test_that("auto + openai model routes to OpenAI", {
     called <- NULL
-    testthat::with_mocked_bindings(
+    testthat::local_mocked_bindings(
         .resolve_model_provider = function(model, openai_api_key = "", ...) {
             data.frame(
                 provider = "openai",
@@ -35,18 +38,16 @@ test_that("auto + openai model routes to OpenAI", {
             called <<- c(called, "local")
             fake_resp(model = payload$model %||% "local-model")
         },
-        {
-            res <- gpt("hi", model = "gpt-4o-mini", provider = "auto",
-                       openai_api_key = "sk-test", print_raw = FALSE)
-            expect_identical(called, "openai")
-        },
         .env = asNamespace("gptr")
     )
+    res <- gpt("hi", model = "gpt-4o-mini", provider = "auto",
+               openai_api_key = "sk-test", print_raw = FALSE)
+    expect_identical(called, "openai")
 })
 
 test_that("auto + local model routes to local", {
     called <- NULL
-    testthat::with_mocked_bindings(
+    testthat::local_mocked_bindings(
         .resolve_model_provider = function(model, openai_api_key = "", ...) {
             data.frame(
                 provider = "lmstudio",
@@ -68,14 +69,12 @@ test_that("auto + local model routes to local", {
             called <<- c(called, "openai")
             fake_resp(model = payload$model %||% "gpt")
         },
-        {
-            res <- gpt("hi", model = "mistralai/mistral-7b-instruct-v0.3",
-                       provider = "auto", print_raw = FALSE)
-            expect_true(length(called) == 1L)
-            expect_match(called, "^local@http://127\\.0\\.0\\.1:1234$")
-        },
         .env = asNamespace("gptr")
     )
+    res <- gpt("hi", model = "mistralai/mistral-7b-instruct-v0.3",
+               provider = "auto", print_raw = FALSE)
+    expect_true(length(called) == 1L)
+    expect_match(called, "^local@http://127\\.0\\.0\\.1:1234$")
 })
 
 test_that("auto + duplicate model prefers locals via gptr.local_prefer", {
@@ -83,7 +82,7 @@ test_that("auto + duplicate model prefers locals via gptr.local_prefer", {
     on.exit(options(old), add = TRUE)
 
     called <- NULL
-    testthat::with_mocked_bindings(
+    testthat::local_mocked_bindings(
         .resolve_model_provider = function(model, openai_api_key = "", ...) {
             data.frame(
                 provider = c("openai", "ollama"),
@@ -104,12 +103,10 @@ test_that("auto + duplicate model prefers locals via gptr.local_prefer", {
             called <<- c(called, "openai")
             fake_resp(model = payload$model %||% "o1-mini")
         },
-        {
-            res <- gpt("hi", model = "o1-mini", provider = "auto", print_raw = FALSE)
-            expect_identical(called, "local@http://127.0.0.1:11434")
-        },
         .env = asNamespace("gptr")
     )
+    res <- gpt("hi", model = "o1-mini", provider = "auto", print_raw = FALSE)
+    expect_identical(called, "local@http://127.0.0.1:11434")
 })
 
 test_that("auto + unknown model errors asking for provider", {
@@ -138,39 +135,35 @@ test_that("auto + unknown model errors asking for provider", {
 })
 
 test_that("auto + model resolution returning NULL errors asking for provider", {
-    testthat::with_mocked_bindings(
+    testthat::local_mocked_bindings(
         .resolve_model_provider = function(model, openai_api_key = "", ...) NULL,
-        {
-            expect_error(
-                gpt("hi", model = "missing", provider = "auto", print_raw = FALSE),
-                "Model 'missing' is not available; specify a provider.",
-                fixed = TRUE
-            )
-        },
         .env = asNamespace("gptr")
+    )
+    expect_error(
+        gpt("hi", model = "missing", provider = "auto", print_raw = FALSE),
+        "Model 'missing' is not available; specify a provider.",
+        fixed = TRUE
     )
 })
 
 test_that("auto + model resolution returning empty data frame errors asking for provider", {
-    testthat::with_mocked_bindings(
+    testthat::local_mocked_bindings(
         .resolve_model_provider = function(model, openai_api_key = "", ...) {
             data.frame(provider = character(), base_url = character(),
                        model_id = character(), stringsAsFactors = FALSE)
         },
-        {
-            expect_error(
-                gpt("hi", model = "missing", provider = "auto", print_raw = FALSE),
-                "Model 'missing' is not available; specify a provider.",
-                fixed = TRUE
-            )
-        },
         .env = asNamespace("gptr")
+    )
+    expect_error(
+        gpt("hi", model = "missing", provider = "auto", print_raw = FALSE),
+        "Model 'missing' is not available; specify a provider.",
+        fixed = TRUE
     )
 })
 
 test_that("auto with no local backend falls back to OpenAI", {
     called <- NULL
-    testthat::with_mocked_bindings(
+    testthat::local_mocked_bindings(
         .resolve_model_provider = function(model, openai_api_key = "", ...) {
             data.frame(provider = character(), base_url = character(),
                        model_id = character(), stringsAsFactors = FALSE)
@@ -187,17 +180,15 @@ test_that("auto with no local backend falls back to OpenAI", {
             called <<- c(called, "local")
             fake_resp(model = payload$model %||% "local")
         },
-        {
-            res <- gpt("hi", provider = "auto", openai_api_key = "sk", print_raw = FALSE)
-            expect_identical(called, "openai")
-        },
         .env = asNamespace("gptr")
     )
+    res <- gpt("hi", provider = "auto", openai_api_key = "sk", print_raw = FALSE)
+    expect_identical(called, "openai")
 })
 
 test_that("provider=openai routes to OpenAI even if locals have models", {
     called <- NULL
-    testthat::with_mocked_bindings(
+    testthat::local_mocked_bindings(
         .fetch_models_cached = function(provider = NULL, base_url = NULL,
                                             openai_api_key = "", ...) {
             list(df = data.frame(id = "gpt-4o-mini", stringsAsFactors = FALSE),
@@ -207,18 +198,16 @@ test_that("provider=openai routes to OpenAI even if locals have models", {
             called <<- c(called, "openai")
             fake_resp(model = payload$model %||% "gpt-4o-mini")
         },
-        {
-            res <- gpt("hi", model = "gpt-4o-mini", provider = "openai",
-                       openai_api_key = "sk-test", print_raw = FALSE)
-            expect_identical(called, "openai")
-        },
         .env = asNamespace("gptr")
     )
+    res <- gpt("hi", model = "gpt-4o-mini", provider = "openai",
+               openai_api_key = "sk-test", print_raw = FALSE)
+    expect_identical(called, "openai")
 })
 
 test_that("missing openai model falls back to default", {
     used <- NULL
-    testthat::with_mocked_bindings(
+    testthat::local_mocked_bindings(
         .fetch_models_cached = function(provider = NULL, base_url = NULL,
                                             openai_api_key = "", ...) {
             list(df = data.frame(id = "gpt-4o-mini", stringsAsFactors = FALSE), status = "ok")
@@ -226,20 +215,18 @@ test_that("missing openai model falls back to default", {
         request_openai = function(payload, base_url, api_key, timeout = 30) {
             used <<- payload$model
             fake_resp(model = payload$model %||% "gpt-4o-mini")
-        },
-        {
-            res <- gpt("hi", model = "unknown", provider = "openai",
-                       openai_api_key = "sk-test", print_raw = FALSE)
-            expect_identical(used, "gpt-4o-mini")
         }
     )
+    res <- gpt("hi", model = "unknown", provider = "openai",
+               openai_api_key = "sk-test", print_raw = FALSE)
+    expect_identical(used, "gpt-4o-mini")
 })
 
 # If the user explicitly says provider = "local" and gives a base_url = "http://…"
 # then that exact URL must be used, not replaced by defaults or by whatever is in the cache.
 test_that("explicit local base_url is honored", {
     called <- NULL
-    testthat::with_mocked_bindings(
+    testthat::local_mocked_bindings(
         .fetch_models_cached = function(provider = NULL, base_url = NULL,
                                             openai_api_key = "", ...) {
             list(df = data.frame(id = "mistralai/mistral-7b-instruct-v0.3",
@@ -249,21 +236,19 @@ test_that("explicit local base_url is honored", {
             called <<- c(called, paste0("local@", base_url))
             fake_resp(model = payload$model %||% "mistral")
         },
-        {
-            res <- gpt("hi",
-                       provider = "local",
-                       base_url = "http://192.168.1.50:1234",
-                       model = "mistralai/mistral-7b-instruct-v0.3",
-                       strict_model = TRUE,
-                       print_raw = FALSE)
-            expect_identical(called, "local@http://192.168.1.50:1234")
-        },
         .env = asNamespace("gptr")
     )
+    res <- gpt("hi",
+               provider = "local",
+               base_url = "http://192.168.1.50:1234",
+               model = "mistralai/mistral-7b-instruct-v0.3",
+               strict_model = TRUE,
+               print_raw = FALSE)
+    expect_identical(called, "local@http://192.168.1.50:1234")
 })
 
 test_that("strict_model errors when model not installed (local)", {
-    testthat::with_mocked_bindings(
+    testthat::local_mocked_bindings(
         .fetch_models_cached = function(provider = NULL, base_url = NULL,
                                             openai_api_key = "", ...) {
             list(df = data.frame(id = "mistral", stringsAsFactors = FALSE), status = "ok")
@@ -271,17 +256,15 @@ test_that("strict_model errors when model not installed (local)", {
         request_local = function(payload, base_url, timeout = 30) {
             fake_resp(model = payload$model %||% "mistral")
         },
-        {
-            expect_error(
-                gpt("hi",
-                    provider = "local",
-                    model = "llama3:latest",
-                    strict_model = TRUE,
-                    print_raw = FALSE),
-                "Model 'llama3:latest' not found"
-            )
-        },
         .env = asNamespace("gptr")
+    )
+    expect_error(
+        gpt("hi",
+            provider = "local",
+            model = "llama3:latest",
+            strict_model = TRUE,
+            print_raw = FALSE),
+        "Model 'llama3:latest' not found"
     )
 })
 
@@ -318,7 +301,7 @@ test_that("strict_model ignored when model listing unavailable", {
 
 test_that("model match is case-insensitive", {
     called <- NULL
-    testthat::with_mocked_bindings(
+    testthat::local_mocked_bindings(
         .resolve_model_provider = function(model, openai_api_key = "", ...) {
             data.frame(
                 provider = "openai",
@@ -335,12 +318,15 @@ test_that("model match is case-insensitive", {
             called <<- "openai"
             fake_resp(model = payload$model %||% "GPT-4O-MINI")
         },
-        {
-            res <- gpt("hi", model = "gpt-4o-mini", provider = "auto",
-                       openai_api_key = "sk-test", print_raw = FALSE)
-            expect_identical(called, "openai")
-        },
         .env = asNamespace("gptr")
     )
+    res <- gpt("hi", model = "gpt-4o-mini", provider = "auto",
+               openai_api_key = "sk-test", print_raw = FALSE)
+    expect_identical(called, "openai")
+})
+
+test_that("no backend mocks persist across tests", {
+    expect_identical(gptr:::.resolve_model_provider, original_resolve_model_provider)
+    expect_identical(gptr:::.fetch_models_cached, original_fetch_models_cached)
 })
 


### PR DESCRIPTION
## Summary
- Refactor backend tests to use `testthat::local_mocked_bindings()` so mocks revert automatically
- Capture original backend helpers and add a test ensuring no mock leaks persist

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b96ad205208321a2e0a4e339c0a708