### PR TITLE
Centralize test cleanup for cache and options

### DIFF
--- a/tests/testthat/setup-gptr.R
+++ b/tests/testthat/setup-gptr.R
@@ -1,0 +1,10 @@
+# Setup hooks for gptr tests
+
+# Capture default gptr.* options at load time
+.gptr_default_options <- options()[grepl("^gptr\\.", names(options()))]
+
+# Ensure each test starts with a clean cache and default options
+testthat::set_hook("test", function(desc, env) {
+  delete_models_cache()
+  withr::local_options(.gptr_default_options, .local_envir = env)
+}, action = "before")

--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -79,8 +79,7 @@ test_that("auto + local model routes to local", {
 })
 
 test_that("auto + duplicate model prefers locals via gptr.local_prefer", {
-    old <- options(gptr.local_prefer = c("ollama","lmstudio","localai"))
-    on.exit(options(old), add = TRUE)
+    withr::local_options(list(gptr.local_prefer = c("ollama","lmstudio","localai")))
 
     called <- NULL
     testthat::with_mocked_bindings(
@@ -113,7 +112,6 @@ test_that("auto + duplicate model prefers locals via gptr.local_prefer", {
 })
 
 test_that("auto + unknown model errors asking for provider", {
-    delete_models_cache()
     called <- character()
     testthat::local_mocked_bindings(
         req_perform = function(req, ...) {
@@ -286,7 +284,6 @@ test_that("strict_model errors when model not installed (local)", {
 })
 
 test_that("strict_model ignored when model listing unavailable", {
-    delete_models_cache()
     called_models <- FALSE
     called_chat <- FALSE
     testthat::local_mocked_bindings(


### PR DESCRIPTION
## Summary
- Ensure each test runs with a clean models cache and default `gptr.*` options via new `setup-gptr.R`
- Remove per-test cache and option resets in backend tests

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b96ad698a08321bd00ca6e1b66e37e