### PR TITLE
Ensure test cache and options reset before backend tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Suggests:
     testthat (>= 3.0.0),
     progressr,
     pkgnet,
-    withr
+    withr (>= 2.5.0)
 Config/testthat/edition: 3
 URL: https://github.com/FrancescoMonti-source/gptr
 BugReports: https://github.com/FrancescoMonti-source/gptr/issues

--- a/tests/testthat/setup-gptr.R
+++ b/tests/testthat/setup-gptr.R
@@ -4,7 +4,6 @@
 .gptr_default_options <- options()[grepl("^gptr\\.", names(options()))]
 
 # Ensure each test starts with a clean cache and default options
-testthat::set_hook("test", function(desc, env) {
-  delete_models_cache()
-  withr::local_options(.gptr_default_options, .local_envir = env)
-}, action = "before")
+delete_models_cache()
+withr::defer(delete_models_cache(), testthat::teardown_env())
+withr::local_options(.gptr_default_options, .local_envir = testthat::teardown_env())


### PR DESCRIPTION
## Summary
- Remove testthat::set_hook test hook from test setup
- Add cache cleanup and default option helpers in test setup
- Require withr and testthat >= 3.0 in DESCRIPTION

## Testing
- `R -q -e 'devtools::test(filter = "backend")'` *(failed: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b96ef078808321a3f9a49e3bc7fa69