### PR TITLE
Ensure backend mocks restored in tests

### DIFF
--- a/tests/testthat/setup-gptr.R
+++ b/tests/testthat/setup-gptr.R
@@ -3,7 +3,19 @@
 # Capture default gptr.* options at load time
 .gptr_default_options <- options()[grepl("^gptr\\.", names(options()))]
 
+# Capture the original backend resolution functions
+.orig_resolve_model_provider <- gptr:::.resolve_model_provider
+.orig_fetch_models_cached    <- gptr:::.fetch_models_cached
+
 # Ensure each test starts with a clean cache and default options
 delete_models_cache()
-withr::defer(delete_models_cache(), testthat::teardown_env())
 withr::local_options(.gptr_default_options, .local_envir = testthat::teardown_env())
+
+withr::defer({
+  assignInNamespace(".resolve_model_provider",
+                    .orig_resolve_model_provider, "gptr")
+  assignInNamespace(".fetch_models_cached",
+                    .orig_fetch_models_cached, "gptr")
+  delete_models_cache()
+}, testthat::teardown_env())
+

--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -11,9 +11,6 @@ fake_resp <- function(model = "dummy") {
     list(body = body, resp = resp)
 }
 
-original_resolve_model_provider <- gptr:::.resolve_model_provider
-original_fetch_models_cached <- gptr:::.fetch_models_cached
-
 test_that("auto + openai model routes to OpenAI", {
     called <- NULL
     testthat::local_mocked_bindings(
@@ -328,7 +325,7 @@ test_that("model match is case-insensitive", {
 })
 
 test_that("no backend mocks persist across tests", {
-    expect_identical(gptr:::.resolve_model_provider, original_resolve_model_provider)
-    expect_identical(gptr:::.fetch_models_cached, original_fetch_models_cached)
+    expect_identical(gptr:::.resolve_model_provider, .orig_resolve_model_provider)
+    expect_identical(gptr:::.fetch_models_cached, .orig_fetch_models_cached)
 })
 


### PR DESCRIPTION
## Summary
- Capture original backend resolution functions in test setup and restore them on teardown
- Remove redundant storage of original bindings from backend tests

## Testing
- `R -q -e 'devtools::test(filter="backends")'` *(fails: command not found: R)*
- `apt-get update` *(fails: repository InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b972693f04832191f94bcfa7a9eeb3