### PR TITLE
feat: add refresh option for live model listing

### DIFF
--- a/R/models_cache.R
+++ b/R/models_cache.R
@@ -166,16 +166,27 @@
 #' Returns a list with a data frame of models (`df`) and a status string.
 #' Branches on provider to apply OpenAI-specific headers and retry logic or
 #' a generic flow for local backends.
+#' @param provider Provider name (e.g., "openai", "ollama").
+#' @param base_url Base URL of the backend.
+#' @param refresh Logical; included for API compatibility. When `TRUE`, any
+#'   cached entry is ignored.
+#' @param openai_api_key OpenAI API key used when `provider = "openai"`.
+#' @param timeout Request timeout in seconds.
 #' @keywords internal
 .fetch_models_live <- function(provider,
                                base_url,
+                               refresh = FALSE,
+                               openai_api_key = Sys.getenv("OPENAI_API_KEY", ""),
                                timeout = getOption("gptr.request_timeout", 5)) {
+  if (isTRUE(refresh)) {
+    # explicit no-op to emphasize refresh semantics
+    NULL
+  }
   if (!requireNamespace("httr2", quietly = TRUE)) {
     return(list(df = data.frame(id = character(0), created = numeric(0)), status = "httr2_missing"))
   }
   if (identical(provider, "openai")) {
-    key <- Sys.getenv("OPENAI_API_KEY", "")
-    .fetch_models_live_openai(base_url, key, timeout)
+    .fetch_models_live_openai(base_url, openai_api_key, timeout)
   } else {
     .fetch_models_live_local(provider, base_url, timeout)
   }
@@ -338,10 +349,10 @@
         ttl <- getOption("gptr.model_cache_ttl", 3600)
         if (!is.na(ent$ts) && (as.numeric(Sys.time()) - ent$ts) < ttl) return(list(df = .as_models_df(ent$models), status = "ok"))
     }
-    live <- .fetch_models_live(provider, base_url)
+    live <- .fetch_models_live(provider, base_url, openai_api_key = openai_api_key)
     if (identical(live$status, "unreachable")) {
         Sys.sleep(0.2)
-        live <- .fetch_models_live(provider, base_url)
+        live <- .fetch_models_live(provider, base_url, openai_api_key = openai_api_key)
         if (identical(live$status, "unreachable")) {
             return(live)
         }
@@ -435,7 +446,7 @@
 #'
 #' Behavior:
 #' - Local providers read from the in-session cache by default (fast). Use `refresh=TRUE`
-#'   to force a live probe of `/v1/models` (Ollama falls back to `/api/tags`).
+#'   to bypass the cache and probe `/v1/models` directly (Ollama falls back to `/api/tags`).
 #' - OpenAI is included if an API key is available (or explicitly provided).
 #' - Output is normalized with an `availability` column:
 #'     * "installed" for local backends
@@ -448,8 +459,8 @@
 #'   "lmstudio","ollama","localai","openai".
 #' @param base_url Optional root URL to target a specific server. If NULL,
 #'   defaults from options are used for locals, and https://api.openai.com for OpenAI.
-#' @param refresh Logical. If TRUE, forces a live probe and updates cache
-#'   (for locals) or bypasses cache (for OpenAI). Defaults to `FALSE`.
+#' @param refresh Logical. If TRUE, bypasses cache and queries providers
+#'   directly. Cached entries are left untouched.
 #' @param openai_api_key Optional OpenAI API key. If missing, falls back to
 #'   Sys.getenv("OPENAI_API_KEY"). If still empty, OpenAI rows will indicate
 #'   an auth_missing status (no stop).
@@ -475,17 +486,25 @@ list_models <- function(provider = NULL,
         localai  = getOption("gptr.localai_base_url", "http://127.0.0.1:8080")
       )
       bu <- .api_root(base_url %||% bu_default)
-      if (isTRUE(refresh)) .cache_del(p, bu)
-      df <- .fetch_models_cached_local(p, bu)
+      if (isTRUE(refresh)) {
+        live <- .fetch_models_live(p, bu, refresh = TRUE)
+        df <- .row_df(p, bu, live$df, "installed", "live", as.numeric(Sys.time()), status = live$status)
+      } else {
+        df <- .fetch_models_cached_local(p, bu)
+      }
       diagnostics[[length(diagnostics) + 1L]] <- attr(df, "diagnostic")
       rows[[length(rows) + 1L]] <- df
     } else if (p == "openai") {
       bu <- .api_root(base_url %||% "https://api.openai.com")
-      if (isTRUE(refresh)) .cache_del("openai", bu)
-      df <- .fetch_models_cached_openai(openai_api_key, bu)
+      if (isTRUE(refresh)) {
+        live <- .fetch_models_live("openai", bu, refresh = TRUE, openai_api_key = openai_api_key)
+        df <- .row_df("openai", bu, live$df, "catalog", "live", as.numeric(Sys.time()), status = live$status)
+      } else {
+        df <- .fetch_models_cached_openai(openai_api_key, bu)
+      }
       diagnostics[[length(diagnostics) + 1L]] <- attr(df, "diagnostic")
       rows[[length(rows) + 1L]] <- df
-  }
+    }
   }
 
 

--- a/man/dot-fetch_models_live.Rd
+++ b/man/dot-fetch_models_live.Rd
@@ -2,21 +2,28 @@
 % Please edit documentation in R/models_cache.R
 \name{.fetch_models_live}
 \alias{.fetch_models_live}
-\title{Perform a live HTTP GET on /v1/models for a given provider and base_url.
-Returns a list with a data frame of models (\code{df}) and a status string.
-Branches on provider to apply OpenAI-specific headers and retry logic or
-a generic flow for local backends.}
+\title{Perform a live HTTP GET on /v1/models for a given provider and base_url. Returns a list with a data frame of models (\code{df}) and a status string. Branches on provider to apply OpenAI-specific headers and retry logic or a generic flow for local backends.}
 \usage{
 .fetch_models_live(
   provider,
   base_url,
+  refresh = FALSE,
+  openai_api_key = Sys.getenv("OPENAI_API_KEY", ""),
   timeout = getOption("gptr.request_timeout", 5)
 )
 }
+\arguments{
+\item{provider}{Provider name (e.g., "openai", "ollama").}
+
+\item{base_url}{Base URL of the backend.}
+
+\item{refresh}{Logical; included for API compatibility. When \code{TRUE}, any cached entry is ignored.}
+
+\item{openai_api_key}{OpenAI API key used when \code{provider = "openai"}.}
+
+\item{timeout}{Request timeout in seconds.}
+}
 \description{
-Perform a live HTTP GET on /v1/models for a given provider and base_url.
-Returns a list with a data frame of models (\code{df}) and a status string.
-Branches on provider to apply OpenAI-specific headers and retry logic or
-a generic flow for local backends.
+Perform a live HTTP GET on /v1/models for a given provider and base_url. Returns a list with a data frame of models (\code{df}) and a status string. Branches on provider to apply OpenAI-specific headers and retry logic or a generic flow for local backends.
 }
 \keyword{internal}

--- a/man/list_models.Rd
+++ b/man/list_models.Rd
@@ -18,8 +18,8 @@ list_models(
 \item{base_url}{Optional root URL to target a specific server. If NULL,
 defaults from options are used for locals, and https://api.openai.com for OpenAI.}
 
-\item{refresh}{Logical. If TRUE, forces a live probe and updates cache
-(for locals) or bypasses cache (for OpenAI). Defaults to \code{FALSE}.}
+\item{refresh}{Logical. If TRUE, bypasses cache and queries providers directly.
+Cached entries are left untouched. Defaults to \code{FALSE}.}
 
 \item{openai_api_key}{Optional OpenAI API key. If missing, falls back to
 Sys.getenv("OPENAI_API_KEY"). If still empty, OpenAI rows will indicate
@@ -35,7 +35,7 @@ Status diagnostics for each backend are also attached via
 Behavior:
 \itemize{
 \item Local providers read from the in-session cache by default (fast). Use \code{refresh=TRUE}
-to force a live probe of \verb{/v1/models} (Ollama falls back to \verb{/api/tags}).
+to bypass the cache and probe \verb{/v1/models} directly (Ollama falls back to \verb{/api/tags}).
 \item OpenAI is included if an API key is available (or explicitly provided).
 \item Output is normalized with an \code{availability} column:
 \itemize{

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -119,67 +119,79 @@ test_that("openai fallback semantics via .fetch_models_live", {
 })
 
 
-test_that("refresh_models handles openai provider", {
-  fake_cache <- make_fake_cache()
-  payload <- openai_models_payload()
-  mock_http_openai(status = 200L, json = payload)
+test_that("refresh_models hits live endpoint for openai", {
+  live_called <- FALSE
+  live_mock <- function(provider, base_url, refresh = FALSE, openai_api_key = "", ...) {
+    live_called <<- TRUE
+    list(df = data.frame(id = c("gpt-4o", "gpt-4.1-mini"), created = c(1, 2)), status = "ok")
+  }
   testthat::local_mocked_bindings(
-    .cache_get = function(p, u) fake_cache$get(p, u),
-    .cache_put = function(p, u, m) fake_cache$put(p, u, m),
-    .cache_del = function(...) invisible(TRUE),
+    .fetch_models_live = live_mock,
+    .cache_get = function(...) stop("cache_get called"),
+    .cache_put = function(...) stop("cache_put called"),
+    .cache_del = function(...) stop("cache_del called"),
     .env = asNamespace("gptr")
   )
   out <- refresh_models(provider = "openai", openai_api_key = "sk-test")
-  expect_true(all(out$provider == "openai"))
+  expect_true(live_called)
   expect_equal(nrow(out), 2L)
-  expect_true(all(out$status == "ok"))
-  cached <- fake_cache$get("openai", "https://api.openai.com")
-  expect_true(NROW(cached$models) == 2)
+  expect_true(all(out$source == "live"))
 })
 
-test_that("refresh_models skips cache when unreachable", {
-  fake_cache <- make_fake_cache()
-  live_mock <- function(provider, base_url) {
+test_that("refresh_models bypasses cache when unreachable", {
+  live_called <- FALSE
+  live_mock <- function(provider, base_url, refresh = FALSE, ...) {
+    live_called <<- TRUE
     list(df = data.frame(id = character(), created = numeric()), status = "unreachable")
   }
   testthat::local_mocked_bindings(
     .fetch_models_live = live_mock,
-    .cache_put = function(p, u, m) fake_cache$put(p, u, m),
-    .cache_get = function(p, u) fake_cache$get(p, u),
-    .cache_del = function(...) invisible(TRUE),
+    .cache_get = function(...) stop("cache_get called"),
+    .cache_put = function(...) stop("cache_put called"),
+    .cache_del = function(...) stop("cache_del called"),
     .env = asNamespace("gptr")
   )
   out <- refresh_models(provider = "lmstudio", base_url = "http://127.0.0.1:1234")
+  expect_true(live_called)
   expect_identical(nrow(out), 1L)
   expect_identical(out$status, "unreachable")
   expect_true(all(is.na(out$model_id)))
-  expect_null(fake_cache$get("lmstudio", "http://127.0.0.1:1234"))
 })
 
-test_that("refresh_models retries after unreachable and caches", {
-  fake_cache <- make_fake_cache()
-  calls <- 0
-  live_mock <- function(provider, base_url) {
-    calls <<- calls + 1
-    if (calls == 1) {
-      list(df = data.frame(id = character(), created = numeric()), status = "unreachable")
-    } else {
-      list(df = data.frame(id = "m1", created = 1), status = "ok")
-    }
-  }
+test_that("list_models refresh=TRUE bypasses cache for locals", {
+  live_called <- FALSE
   testthat::local_mocked_bindings(
-    .fetch_models_live = live_mock,
-    .cache_put = function(p, u, m) fake_cache$put(p, u, m),
-    .cache_get = function(p, u) fake_cache$get(p, u),
-    .cache_del = function(...) invisible(TRUE),
+    .fetch_models_live = function(provider, base_url, refresh = FALSE, ...) {
+      live_called <<- TRUE
+      list(df = data.frame(id = "m1", created = 1), status = "ok")
+    },
+    .fetch_models_cached_local = function(...) stop("cached_local called"),
+    .cache_get = function(...) stop("cache_get called"),
+    .cache_put = function(...) stop("cache_put called"),
+    .cache_del = function(...) stop("cache_del called"),
     .env = asNamespace("gptr")
   )
-  out <- refresh_models(provider = "lmstudio", base_url = "http://127.0.0.1:1234")
-  expect_identical(nrow(out), 1L)
-  expect_identical(out$status, "ok")
-  expect_identical(out$model_id, "m1")
-  cached <- fake_cache$get("lmstudio", "http://127.0.0.1:1234")
-  expect_identical(cached$models$id, "m1")
+  out <- list_models(provider = "lmstudio", refresh = TRUE)
+  expect_true(live_called)
+  expect_identical(out$source, "live")
+})
+
+test_that("list_models refresh=TRUE bypasses cache for openai", {
+  live_called <- FALSE
+  testthat::local_mocked_bindings(
+    .fetch_models_live = function(provider, base_url, refresh = FALSE, openai_api_key = "", ...) {
+      live_called <<- TRUE
+      list(df = data.frame(id = "gpt-4o", created = 1), status = "ok")
+    },
+    .fetch_models_cached_openai = function(...) stop("cached_openai called"),
+    .cache_get = function(...) stop("cache_get called"),
+    .cache_put = function(...) stop("cache_put called"),
+    .cache_del = function(...) stop("cache_del called"),
+    .env = asNamespace("gptr")
+  )
+  out <- list_models(provider = "openai", refresh = TRUE, openai_api_key = "sk-test")
+  expect_true(live_called)
+  expect_identical(out$source, "live")
 })
 
 test_that(".fetch_models_cached skips cache when unreachable", {


### PR DESCRIPTION
## Summary
- allow `.fetch_models_live()` to accept a `refresh` flag and explicit OpenAI API key
- `list_models(refresh = TRUE)` now bypasses cache and queries providers directly
- document refresh behavior and add tests for cache bypass

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed; unable to install R)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b0c4a738832192b1d4aad8753db1