### PR TITLE
Resolve merge conflicts in model caching

### DIFF
--- a/man/fetch_models_live.Rd
+++ b/man/fetch_models_live.Rd
@@ -2,22 +2,28 @@
 % Please edit documentation in R/models_cache.R
 \name{fetch_models_live}
 \alias{fetch_models_live}
-\title{Perform a live HTTP GET on /v1/models for a given provider and base_url.
-Returns a list with a data frame of models (\code{df}) and a status string.
-Branches on provider to apply OpenAI-specific headers and retry logic or
-a generic flow for local backends.}
+\title{Perform a live HTTP GET on /v1/models for a given provider and base_url. Returns a list with a data frame of models (\code{df}) and a status string. Branches on provider to apply OpenAI-specific headers and retry logic or a generic flow for local backends.}
 \usage{
 fetch_models_live(
   provider,
   base_url,
+  refresh = FALSE,
   openai_api_key = Sys.getenv("OPENAI_API_KEY", ""),
   timeout = getOption("gptr.request_timeout", 5)
 )
 }
+\arguments{
+\item{provider}{Provider name (e.g., "openai", "ollama").}
+
+\item{base_url}{Base URL of the backend.}
+
+\item{refresh}{Logical; included for API compatibility. When \code{TRUE}, any cached entry is ignored.}
+
+\item{openai_api_key}{OpenAI API key used when \code{provider = "openai"}.}
+
+\item{timeout}{Request timeout in seconds.}
+}
 \description{
-Perform a live HTTP GET on /v1/models for a given provider and base_url.
-Returns a list with a data frame of models (\code{df}) and a status string.
-Branches on provider to apply OpenAI-specific headers and retry logic or
-a generic flow for local backends.
+Perform a live HTTP GET on /v1/models for a given provider and base_url. Returns a list with a data frame of models (\code{df}) and a status string. Branches on provider to apply OpenAI-specific headers and retry logic or a generic flow for local backends.
 }
 \keyword{internal}

--- a/man/list_models.Rd
+++ b/man/list_models.Rd
@@ -18,8 +18,8 @@ list_models(
 \item{base_url}{Optional root URL to target a specific server. If NULL,
 defaults from options are used for locals, and https://api.openai.com for OpenAI.}
 
-\item{refresh}{Logical. If TRUE, forces a live probe and updates cache
-(for locals) or bypasses cache (for OpenAI). Defaults to \code{FALSE}.}
+\item{refresh}{Logical. If TRUE, bypasses cache and queries providers directly.
+Cached entries are left untouched. Defaults to \code{FALSE}.}
 
 \item{openai_api_key}{Optional OpenAI API key. If missing, falls back to
 Sys.getenv("OPENAI_API_KEY"). If still empty, OpenAI rows will indicate
@@ -35,7 +35,7 @@ Status diagnostics for each backend are also attached via
 Behavior:
 \itemize{
 \item Local providers read from the in-session cache by default (fast). Use \code{refresh=TRUE}
-to force a live probe of \verb{/v1/models} (Ollama falls back to \verb{/api/tags}).
+to bypass the cache and probe \verb{/v1/models} directly (Ollama falls back to \verb{/api/tags}).
 \item OpenAI is included if an API key is available (or explicitly provided).
 \item Output is normalized with an \code{availability} column:
 \itemize{


### PR DESCRIPTION
## Summary
- add optional `refresh` flag to `fetch_models_live`
- call `fetch_models_live` consistently in cached fetches and listings
- update tests for refreshed model caching flow

## Testing
- ❌ `R -q -e "devtools::test()"` *(command not found)*
- ⚠️ `apt-get update` *(403  Forbidden [IP: 172.30.0.35 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68b9b5493d5883218bbc662ed5626bf8