### PR TITLE
Unify model caching across providers

### DIFF
--- a/R/gpt.R
+++ b/R/gpt.R
@@ -90,7 +90,7 @@ gpt <- function(prompt,
             for (bk in prefer) {
                 lm <- try(.fetch_models_cached(provider = bk, base_url = roots[[bk]],
                                                    openai_api_key = openai_api_key), silent = TRUE)
-                if (!inherits(lm, "try-error") && is.list(lm) && NROW(lm$df)) {
+                if (!inherits(lm, "try-error") && is.data.frame(lm) && NROW(lm)) {
                     base_root <- .api_root(roots[[bk]])
                     backend   <- bk
                     picked    <- TRUE
@@ -175,7 +175,7 @@ gpt <- function(prompt,
         }
         ids <- tryCatch(
             .fetch_models_cached(provider = "openai", base_url = bu_root,
-                                     openai_api_key = defs$api_key)$df$id,
+                                     openai_api_key = defs$api_key)$model_id,
             error = function(e) character(0)
         )
         if (length(ids) && !tolower(defs$model) %in% tolower(ids)) {
@@ -203,8 +203,8 @@ gpt <- function(prompt,
 
         ent <- try(.fetch_models_cached(provider = backend, base_url = base_root,
                                            openai_api_key = openai_api_key), silent = TRUE)
-        ids <- if (!inherits(ent, "try-error") && is.list(ent) && !is.null(ent$df)) {
-            unique(na.omit(as.character(ent$df$id)))
+        ids <- if (!inherits(ent, "try-error") && is.data.frame(ent)) {
+            unique(na.omit(as.character(ent$model_id)))
         } else character(0)
 
         if (isTRUE(strict_model) && !length(ids)) strict_model <- FALSE

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -165,7 +165,7 @@ test_that("list_models refresh=TRUE bypasses cache for locals", {
       live_called <<- TRUE
       list(df = data.frame(id = "m1", created = 1), status = "ok")
     },
-    .fetch_models_cached_local = function(...) stop("cached_local called"),
+    .fetch_models_cached = function(...) stop("cached called"),
     .cache_get = function(...) stop("cache_get called"),
     .cache_put = function(...) stop("cache_put called"),
     .cache_del = function(...) stop("cache_del called"),
@@ -183,7 +183,7 @@ test_that("list_models refresh=TRUE bypasses cache for openai", {
       live_called <<- TRUE
       list(df = data.frame(id = "gpt-4o", created = 1), status = "ok")
     },
-    .fetch_models_cached_openai = function(...) stop("cached_openai called"),
+    .fetch_models_cached = function(...) stop("cached called"),
     .cache_get = function(...) stop("cache_get called"),
     .cache_put = function(...) stop("cache_put called"),
     .cache_del = function(...) stop("cache_del called"),
@@ -207,7 +207,8 @@ test_that(".fetch_models_cached skips cache when unreachable", {
     .env = asNamespace("gptr")
   )
   out <- f("lmstudio", "http://127.0.0.1:1234")
-  expect_identical(out$status, "unreachable")
+  diag <- attr(out, "diagnostic")
+  expect_identical(diag$status, "unreachable")
   expect_identical(nrow(out$df), 0L)
   expect_null(fake_cache$get("lmstudio", "http://127.0.0.1:1234"))
 })
@@ -465,10 +466,8 @@ test_that("list_models - second call uses cache when available", {
 
 
 
-test_that(".fetch_models_cached_* helpers are present", {
-  f_local <- getFromNamespace(".fetch_models_cached_local", "gptr")
-  f_openai <- getFromNamespace(".fetch_models_cached_openai", "gptr")
-  expect_type(f_local, "closure")
-  expect_type(f_openai, "closure")
+test_that(".fetch_models_cached helper is present", {
+  f <- getFromNamespace(".fetch_models_cached", "gptr")
+  expect_type(f, "closure")
 })
 

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -326,6 +326,25 @@ test_that(".fetch_models_cached enumerates cache contents", {
   expect_equal(out$n_models[out$provider == "openai"], 1L)
 })
 
+test_that(".fetch_models_cached defaults base_url per provider", {
+  f <- getFromNamespace(".fetch_models_cached", "gptr")
+  testthat::local_mocked_bindings(
+    .fetch_models_live = function(provider, base_url, ...) {
+      list(df = data.frame(id = "m1", created = 1), status = "ok")
+    },
+    .cache_get = function(...) NULL,
+    .cache_put = function(...) NULL,
+    .env = asNamespace("gptr")
+  )
+  withr::local_envvar(OPENAI_API_KEY = "sk-test")
+
+  out1 <- f("lmstudio")
+  expect_equal(unique(out1$base_url), "http://127.0.0.1:1234")
+
+  out2 <- f("openai")
+  expect_equal(unique(out2$base_url), "https://api.openai.com")
+})
+
 test_that("invalidate clears cache", {
   inv <- getFromNamespace("delete_models_cache", "gptr")
   cache <- getFromNamespace(".gptr_cache", "gptr")


### PR DESCRIPTION
## Summary
- merge local and OpenAI caching into one `.fetch_models_cached()` helper
- call unified cache from `list_models()` and internal provider resolution
- update tests for consolidated caching workflow

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bb614ebc83219bb8612d7fe8ff5c