### PR TITLE
Allow refresh to bypass model cache

### DIFF
--- a/R/models_cache.R
+++ b/R/models_cache.R
@@ -168,8 +168,10 @@
 #' a generic flow for local backends.
 #' @param provider Provider name (e.g., "openai", "ollama").
 #' @param base_url Base URL of the backend.
-#' @param refresh Logical; included for API compatibility. When `TRUE`, any
-#'   cached entry is ignored.
+#' @param refresh Logical flag indicating whether the caller wishes to bypass
+#'   cached results.  This function itself always performs a live request and
+#'   does not read from or write to the cache, but downstream callers use the
+#'   flag to signal a cache bypass.
 #' @param openai_api_key OpenAI API key used when `provider = "openai"`.
 #' @param timeout Request timeout in seconds.
 #' @keywords internal
@@ -178,10 +180,6 @@
                                refresh = FALSE,
                                openai_api_key = Sys.getenv("OPENAI_API_KEY", ""),
                                timeout = getOption("gptr.request_timeout", 5)) {
-  if (isTRUE(refresh)) {
-    # explicit no-op to emphasize refresh semantics
-    NULL
-  }
   if (!requireNamespace("httr2", quietly = TRUE)) {
     return(list(df = data.frame(id = character(0), created = numeric(0)), status = "httr2_missing"))
   }
@@ -400,8 +398,15 @@
         stringsAsFactors = FALSE
     )
 }
+#' @param refresh Logical; if TRUE, the cache is skipped and the backend is
+#'   queried directly without reading from or writing to the cache.
 #' @keywords internal
-.fetch_models_cached_local <- function(provider, base_url) {
+.fetch_models_cached_local <- function(provider, base_url, refresh = FALSE) {
+  if (isTRUE(refresh)) {
+    live <- .fetch_models_live(provider, base_url, refresh = TRUE)
+    ts <- as.numeric(Sys.time())
+    return(.row_df(provider, base_url, live$df, "installed", "live", ts, status = live$status))
+  }
   ent <- .cache_get(provider, base_url)
   if (is.null(ent)) {
     live <- .fetch_models_cached(provider, base_url)
@@ -419,9 +424,17 @@
   }
 }
 
+#' @param refresh Logical; if TRUE, bypasses cache and probes the OpenAI
+#'   endpoint directly without touching the cache.
 #' @keywords internal
 .fetch_models_cached_openai <- function(openai_api_key,
-                                        base_url = "https://api.openai.com") {
+                                        base_url = "https://api.openai.com",
+                                        refresh = FALSE) {
+  if (isTRUE(refresh)) {
+    live <- .fetch_models_live("openai", base_url, refresh = TRUE, openai_api_key = openai_api_key)
+    ts <- as.numeric(Sys.time())
+    return(.row_df("openai", base_url, live$df, "catalog", "live", ts, status = live$status))
+  }
   ent <- .cache_get("openai", base_url)
   if (is.null(ent)) {
     live <- .fetch_models_live_openai(base_url, openai_api_key)
@@ -447,6 +460,7 @@
 #' Behavior:
 #' - Local providers read from the in-session cache by default (fast). Use `refresh=TRUE`
 #'   to bypass the cache and probe `/v1/models` directly (Ollama falls back to `/api/tags`).
+#'   When refreshing, cached entries are neither read nor updated.
 #' - OpenAI is included if an API key is available (or explicitly provided).
 #' - Output is normalized with an `availability` column:
 #'     * "installed" for local backends
@@ -486,22 +500,12 @@ list_models <- function(provider = NULL,
         localai  = getOption("gptr.localai_base_url", "http://127.0.0.1:8080")
       )
       bu <- .api_root(base_url %||% bu_default)
-      if (isTRUE(refresh)) {
-        live <- .fetch_models_live(p, bu, refresh = TRUE)
-        df <- .row_df(p, bu, live$df, "installed", "live", as.numeric(Sys.time()), status = live$status)
-      } else {
-        df <- .fetch_models_cached_local(p, bu)
-      }
+      df <- .fetch_models_cached_local(p, bu, refresh = refresh)
       diagnostics[[length(diagnostics) + 1L]] <- attr(df, "diagnostic")
       rows[[length(rows) + 1L]] <- df
     } else if (p == "openai") {
       bu <- .api_root(base_url %||% "https://api.openai.com")
-      if (isTRUE(refresh)) {
-        live <- .fetch_models_live("openai", bu, refresh = TRUE, openai_api_key = openai_api_key)
-        df <- .row_df("openai", bu, live$df, "catalog", "live", as.numeric(Sys.time()), status = live$status)
-      } else {
-        df <- .fetch_models_cached_openai(openai_api_key, bu)
-      }
+      df <- .fetch_models_cached_openai(openai_api_key, bu, refresh = refresh)
       diagnostics[[length(diagnostics) + 1L]] <- attr(df, "diagnostic")
       rows[[length(rows) + 1L]] <- df
     }

--- a/man/dot-fetch_models_live.Rd
+++ b/man/dot-fetch_models_live.Rd
@@ -20,8 +20,9 @@ a generic flow for local backends.}
 
 \item{base_url}{Base URL of the backend.}
 
-\item{refresh}{Logical; included for API compatibility. When \code{TRUE}, any
-cached entry is ignored.}
+\item{refresh}{Logical flag indicating whether the caller wishes to bypass
+cached results. The function always performs a live request and does not read
+from or write to the cache.}
 
 \item{openai_api_key}{OpenAI API key used when \code{provider = "openai"}.}
 

--- a/man/list_models.Rd
+++ b/man/list_models.Rd
@@ -36,6 +36,7 @@ Behavior:
 \itemize{
 \item Local providers read from the in-session cache by default (fast). Use \code{refresh=TRUE}
 to bypass the cache and probe \verb{/v1/models} directly (Ollama falls back to \verb{/api/tags}).
+When refreshing, cached entries are neither read nor updated.
 \item OpenAI is included if an API key is available (or explicitly provided).
 \item Output is normalized with an \code{availability} column:
 \itemize{

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -165,7 +165,6 @@ test_that("list_models refresh=TRUE bypasses cache for locals", {
       live_called <<- TRUE
       list(df = data.frame(id = "m1", created = 1), status = "ok")
     },
-    .fetch_models_cached_local = function(...) stop("cached_local called"),
     .cache_get = function(...) stop("cache_get called"),
     .cache_put = function(...) stop("cache_put called"),
     .cache_del = function(...) stop("cache_del called"),
@@ -183,7 +182,6 @@ test_that("list_models refresh=TRUE bypasses cache for openai", {
       live_called <<- TRUE
       list(df = data.frame(id = "gpt-4o", created = 1), status = "ok")
     },
-    .fetch_models_cached_openai = function(...) stop("cached_openai called"),
     .cache_get = function(...) stop("cache_get called"),
     .cache_put = function(...) stop("cache_put called"),
     .cache_del = function(...) stop("cache_del called"),


### PR DESCRIPTION
## Summary
- Make `.fetch_models_live()` aware of refresh flag and expose cache-bypass semantics
- Route `list_models()` through cached helpers with refresh support
- Document and test refresh behaviour for models cache

## Testing
- ⚠️ `R -q -e "roxygen2::roxygenise()"` (command not found)
- ⚠️ `R -q -e "devtools::test()"` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b9b94105348321924005d3995482e8