### PR TITLE
refactor live model fetching

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # gptr (development version)
 
 * Renamed internal helpers for clarity: `.collect_local_models` → `.fetch_local_models_cached` and `.collect_openai_models` → `.fetch_openai_models_cached`.
-* `.list_models_live` and provider-specific variants are now `.fetch_models_live`, `.fetch_models_live_openai`, and `.fetch_models_live_local` for clearer intent.
+* `.fetch_models_live` now handles OpenAI and local providers directly; removed provider-specific helpers.
 * `list_models()` now defaults to `refresh = FALSE`; use new `refresh_models()` (replacing `refresh_models_cache()`) to force a live probe.
 
 # gptr 0.4.3


### PR DESCRIPTION
## Summary
- inline OpenAI and local HTTP logic into `.fetch_models_live`
- remove provider-specific live fetchers and add shared parsing helpers
- document unified behavior in NEWS

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found: R)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bb639c6083218eb634205b44ce2b