### PR TITLE
Guard nrow call after Ollama tag fallback

### DIFF
--- a/R/models_cache.R
+++ b/R/models_cache.R
@@ -392,10 +392,10 @@ fetch_models_cached <- function(provider,
   ent <- .cache_get(provider, base_url)
   if (is.null(ent)) {
     live <- .fetch_models_live(provider, base_url, openai_api_key = openai_api_key)
-    mods <- live$df
+    mods <- .as_models_df(live$df)
     ts <- as.numeric(Sys.time())
     if (provider == "ollama" && nrow(mods) == 0) {
-      mods <- .ollama_tags_live(base_url)
+      mods <- .as_models_df(.ollama_tags_live(base_url))
     }
     if (identical(live$status, "ok") && nrow(mods) > 0) {
       .cache_put(provider, base_url, mods)


### PR DESCRIPTION
## Summary
- coerce Ollama tag fallback to model data frame before caching

## Testing
- ⚠️ `R -q -e 'devtools::test()'` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d29f52fc8321bc2e0406ad2efa72