### PR TITLE
Remove Ollama tags fallback

### DIFF
--- a/dev/structure/internals.txt
+++ b/dev/structure/internals.txt
@@ -19,7 +19,6 @@ $.gpt_chat_callable
 .fetch_models_live
 .models_endpoint
 .normalize_token
-.ollama_tags_live
 .onAttach
 .onLoad
 .packageName

--- a/man/list_models.Rd
+++ b/man/list_models.Rd
@@ -35,7 +35,7 @@ Status diagnostics for each backend are also attached via
 Behavior:
 \itemize{
 \item Local providers read from the in-session cache by default (fast). Use \code{refresh=TRUE}
-to bypass the cache and probe \verb{/v1/models} directly (Ollama falls back to \verb{/api/tags}).
+to bypass the cache and probe \verb{/v1/models} directly.
 When refreshing, cached entries are neither read nor updated.
 \item OpenAI is included if an API key is available (or explicitly provided).
 \item Output is normalized with an \code{availability} column:

--- a/tests/testthat/helper-models_cache.R
+++ b/tests/testthat/helper-models_cache.R
@@ -123,10 +123,3 @@ openai_models_payload <- function() {
   )
 }
 
-ollama_tags_payload <- function() {
-  list(models = data.frame(
-    name = c("mistral:instruct", "llama3.1"),
-    stringsAsFactors = FALSE
-  ))
-}
-

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -17,7 +17,7 @@ test_that(".cache_key", {
   ck <- getFromNamespace(".cache_key", "gptr")
   a1 <- ck("openai", "https://api.openai.com")
   a2 <- ck("openai", "https://api.openai.com")
-  b <- ck("ollama", "http://127.0.0.1:11434")
+  b <- ck("lmstudio", "http://127.0.0.1:1234")
   expect_identical(a1, a2)
   expect_false(identical(a1, b))
 })


### PR DESCRIPTION
## Summary
- drop Ollama `/api/tags` fallback and remove `.ollama_tags_live`
- clean up docs referencing the tags fallback
- update tests to drop obsolete Ollama tags logic

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ebcdf2988321a5cc35f15df76c33