### PR TITLE
refactor: rename models endpoint helper

### DIFF
--- a/R/models_cache.R
+++ b/R/models_cache.R
@@ -29,8 +29,10 @@
   x
 }
 
-# Given a root, build the canonical /v1/models endpoint URL for probing model lists.
-.models_endpoint <- function(root) paste0(.api_root(root), "/v1/models")
+#' @keywords internal
+#' @param root Base URL root for a provider.
+#' @returns Canonical `/v1/models` endpoint URL.
+.build_models_url <- function(root) paste0(.api_root(root), "/v1/models")
 
 
 
@@ -115,7 +117,7 @@
   if (!requireNamespace("httr2", quietly = TRUE)) {
     return(list(df = .as_models_df(NULL), status = "httr2_missing"))
   }
-  url <- .models_endpoint(base_url)
+  url <- .build_models_url(base_url)
   req <- httr2::request(url) %>%
     httr2::req_timeout(timeout)
 

--- a/dev/structure/internals.txt
+++ b/dev/structure/internals.txt
@@ -17,7 +17,7 @@ $.gpt_chat_callable
 .list_local_backends
 .fetch_models_cached
 .fetch_models_live
-.models_endpoint
+.build_models_url
 .normalize_token
 .onAttach
 .onLoad


### PR DESCRIPTION
## Summary
- rename `.models_endpoint` helper to `.build_models_url`
- update `.fetch_models_live()` and internals list for new name

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba17b2bd108321bf85c3cd0848ff0f