### PR TITLE
Avoid redundant base URL normalization in model cache

### DIFF
--- a/R/gpt.R
+++ b/R/gpt.R
@@ -169,7 +169,7 @@ gpt <- function(prompt,
         msgs <- openai_build_messages(system = system, user = prompt, image_paths = image_paths)
         defs <- .resolve_openai_defaults(model = model, base_url = base_url, api_key = openai_api_key)
         bu_root <- .api_root(defs$base_url)
-        if (is.null(.cache_get("openai", bu_root))) {
+        if (is.null(.cache_get("openai", bu_root, base_url_normalized = TRUE))) {
             invisible(try(.fetch_models_cached(provider = "openai", base_url = bu_root,
                                                   openai_api_key = defs$api_key), silent = TRUE))
         }

--- a/man/dot-cache_del.Rd
+++ b/man/dot-cache_del.Rd
@@ -4,7 +4,7 @@
 \alias{.cache_del}
 \title{Remove a cache entry for provider+base_url from the cache.}
 \usage{
-.cache_del(provider, base_url)
+.cache_del(provider, base_url, base_url_normalized = FALSE)
 }
 \description{
 Remove a cache entry for provider+base_url from the cache.

--- a/man/dot-cache_put.Rd
+++ b/man/dot-cache_put.Rd
@@ -4,7 +4,7 @@
 \alias{.cache_put}
 \title{Save a cache entry for provider+base_url with a vector of model IDs and timestamp.}
 \usage{
-.cache_put(provider, base_url, models)
+.cache_put(provider, base_url, models, base_url_normalized = FALSE)
 }
 \description{
 Save a cache entry for provider+base_url with a vector of model IDs and timestamp.

--- a/man/dot-get_cached_model_ids.Rd
+++ b/man/dot-get_cached_model_ids.Rd
@@ -7,7 +7,8 @@
 .get_cached_model_ids(
   provider,
   base_url,
-  openai_api_key = Sys.getenv("OPENAI_API_KEY", "")
+  openai_api_key = Sys.getenv("OPENAI_API_KEY", ""),
+  base_url_normalized = FALSE
 )
 }
 \description{


### PR DESCRIPTION
## Summary
- add `base_url_normalized` option to cache helpers and `.get_cached_model_ids`
- normalize provider URLs once in `.resolve_model_provider`
- cover URL normalization and provider resolution with regression tests

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*
- `Rscript -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1bcdfd3c8321aa63dc11c3d6f4af