### PR TITLE
Replace typographic quotes in gpt docs

### DIFF
--- a/R/gpt.R
+++ b/R/gpt.R
@@ -7,8 +7,8 @@
 #' @param model Optional model id. If NULL, resolved per provider defaults.
 #' @param temperature Numeric scalar (default 0.2).
 #' @param provider One of "auto", "local", "openai", "lmstudio", "ollama", "localai".
-#' @param base_url “Optional. Pin a specific local endpoint (…/v1 or …/v1/chat/completions).”
-#' @param backend “Optional. When provider is local, choose a running backend ('lmstudio', 'ollama', 'localai').”
+#' @param base_url "Optional. Pin a specific local endpoint (…/v1 or …/v1/chat/completions)."
+#' @param backend "Optional. When provider is local, choose a running backend ('lmstudio', 'ollama', 'localai')."
 #' @param openai_api_key Optional API key for OpenAI; defaults to env var.
 #' @param image_path Optional path or vector of paths to images to include.
 #' @param system Optional system prompt.

--- a/man/gpt.Rd
+++ b/man/gpt.Rd
@@ -31,7 +31,7 @@ gpt(
 
 \item{provider}{One of "auto", "local", "openai", "lmstudio", "ollama", "localai".}
 
-\item{base_url}{“Optional. Pin a specific local endpoint (…/v1 or …/v1/chat/completions).”}
+\item{base_url}{"Optional. Pin a specific local endpoint (…/v1 or …/v1/chat/completions)."}
 
 \item{openai_api_key}{Optional API key for OpenAI; defaults to env var.}
 
@@ -43,7 +43,7 @@ gpt(
 
 \item{response_format}{NULL, "json_object", or a full list (OpenAI API shape).}
 
-\item{backend}{“Optional. When provider is local, choose a running backend ('lmstudio', 'ollama', 'localai').”}
+\item{backend}{"Optional. When provider is local, choose a running backend ('lmstudio', 'ollama', 'localai')."}
 
 \item{print_raw}{Logical. If TRUE, pretty-print a compact response skeleton and return it immediately (skips any post-processing). Default FALSE.}
 


### PR DESCRIPTION
## Summary
- Use standard ASCII double quotes for `base_url` and `backend` parameters in `gpt()` documentation
- Refresh corresponding Rd file

## Testing
- `R -q -e 'devtools::document()'` *(fails: R not installed)*
- `R -q -e 'devtools::test()'` *(fails: R not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68bb0e7658d88321b8a3fd4decc776b1