### PR TITLE
Remove Remotes field from DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,4 +42,3 @@ Suggests:
 Config/testthat/edition: 3
 URL: https://github.com/FrancescoMonti-source/gptr
 BugReports: https://github.com/FrancescoMonti-source/gptr/issues
-Remotes: r-lib/withr


### PR DESCRIPTION
## Summary
- drop `Remotes: r-lib/withr` to rely on CRAN release
- confirm `withr` dependency via `Suggests: withr (>= 2.5.0)`

## Testing
- `R -q -e 'devtools::check()'` *(fails: R not installed)*
- `apt-get update` *(fails: repository not signed, 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0e94359c83219afcc12606be2d0d