### PR TITLE
Refine model ID flattening helper

### DIFF
--- a/R/models_cache.R
+++ b/R/models_cache.R
@@ -73,26 +73,24 @@
 }
 
 #' @keywords internal
-.extract_model_ids <- function(obj) {
-  if (is.list(obj$data)) {
-    return(vapply(obj$data, function(m) m$id %||% "", ""))
+.flatten_model_ids <- function(obj) {
+  ids <- if (is.list(obj$data)) {
+    vapply(obj$data, function(m) m$id %||% "", "")
+  } else if (is.list(obj$models)) {
+    vapply(obj$models, function(m) m$id %||% "", "")
+  } else if (is.list(obj)) {
+    vapply(obj, function(m) m$id %||% "", "")
+  } else if (is.character(obj)) {
+    obj
+  } else {
+    character(0)
   }
-  if (is.list(obj$models)) {
-    return(vapply(obj$models, function(m) m$id %||% "", ""))
-  }
-  if (is.list(obj)) {
-    return(vapply(obj, function(m) m$id %||% "", ""))
-  }
-  if (is.character(obj)) {
-    return(obj)
-  }
-  character(0)
+  unique(ids[nzchar(ids)])
 }
 
 #' @keywords internal
 .parse_local_models <- function(obj) {
-  ids <- .extract_model_ids(obj)
-  ids <- unique(ids[nzchar(ids)])
+  ids <- .flatten_model_ids(obj)
   .as_models_df(ids)
 }
 

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -1,3 +1,35 @@
+# .flatten_model_ids()
+test_that(".flatten_model_ids handles response shapes", {
+  f <- getFromNamespace(".flatten_model_ids", "gptr")
+
+  obj1 <- list(data = list(
+    list(id = "a"),
+    list(id = "b"),
+    list(id = "a"),
+    list(id = "")
+  ))
+  expect_identical(f(obj1), c("a", "b"))
+
+  obj2 <- list(models = list(
+    list(id = "c"),
+    list(id = "c"),
+    list(id = "d")
+  ))
+  expect_identical(f(obj2), c("c", "d"))
+
+  obj3 <- list(
+    list(id = "e"),
+    list(id = ""),
+    list(id = "f")
+  )
+  expect_identical(f(obj3), c("e", "f"))
+
+  obj4 <- c("g", "", "h", "g")
+  expect_identical(f(obj4), c("g", "h"))
+
+  expect_identical(f(42), character(0))
+})
+
 # api_root()
 # normalization trims trailing /v1/chat/completions
 # keeps scheme/host


### PR DESCRIPTION
## Summary
- rename `.extract_model_ids` to `.flatten_model_ids` and filter duplicates/empties
- update `.parse_local_models` to rely on flattened IDs
- add tests for `.flatten_model_ids` across response shapes

## Testing
- `R -q -e 'devtools::test(filter="models-cache")'` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1be00e2483218c0b825e957fea54