### PR TITLE
Clarify cache helper documentation

### DIFF
--- a/R/utils-cache.R
+++ b/R/utils-cache.R
@@ -1,6 +1,13 @@
-#' list_models() helprer
-#'  internal
-#'  base_url_normalized Logical; set TRUE when base_url is already normalized
+#' Convert objects to a models data frame
+#'
+#' Normalizes various representations of model metadata into a data frame
+#' with `id` and `created` columns.
+#'
+#' @param x Object to convert. Can be `NULL`, a data frame, character vector,
+#'   named vector, or list describing model IDs and creation times.
+#'
+#' @return A data frame with columns `id` and `created`.
+#' @keywords internal
 .as_models_df <- function(x) {
     if (is.null(x)) {
         return(data.frame(id = character(0), created = numeric(0), stringsAsFactors = FALSE))
@@ -50,9 +57,21 @@
     data.frame(id = character(0), created = numeric(0), stringsAsFactors = FALSE)
 }
 
-#' list_models() helper
+#' Create a row for the models cache
+#'
+#' Builds a data frame representing model information returned by a provider.
+#'
+#' @param provider Character identifier of the model provider.
+#' @param base_url Base URL of the provider's API.
+#' @param models_df Data frame of models to expand into rows.
+#' @param availability Character vector indicating model availability.
+#' @param src Source of the model information.
+#' @param ts Numeric timestamp when the data were cached.
+#' @param status Character string describing the request status.
+#' @param base_url_normalized Logical; set `TRUE` when `base_url` is already normalized.
+#'
+#' @return A data frame with one row per model and a diagnostic attribute.
 #' @keywords internal
-#' @param base_url_normalized Logical; set TRUE when base_url is already normalized
 .row_df <- function(provider, base_url, models_df, availability, src, ts, status = NA_character_, base_url_normalized = FALSE) {
     base_url <- if (base_url_normalized) base_url else .api_root(base_url)
     models_df <- .as_models_df(models_df)

--- a/man/dot-as_models_df.Rd
+++ b/man/dot-as_models_df.Rd
@@ -2,14 +2,17 @@
 % Please edit documentation in R/utils-cache.R
 \name{.as_models_df}
 \alias{.as_models_df}
-\title{list_models() helprer
-internal
-base_url_normalized Logical; set TRUE when base_url is already normalized}
+\title{Convert objects to a models data frame}
 \usage{
 .as_models_df(x)
 }
-\description{
-list_models() helprer
-internal
-base_url_normalized Logical; set TRUE when base_url is already normalized
+\arguments{
+\item{x}{Object to convert. Can be \code{NULL}, a data frame, character vector, named vector, or list describing model IDs and creation times.}
 }
+\value{
+A data frame with columns \code{id} and \code{created}.
+}
+\description{
+Normalizes various representations of model metadata into a data frame with \code{id} and \code{created} columns.
+}
+\keyword{internal}

--- a/man/dot-row_df.Rd
+++ b/man/dot-row_df.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/utils-cache.R
 \name{.row_df}
 \alias{.row_df}
-\title{list_models() helper}
+\title{Create a row for the models cache}
 \usage{
 .row_df(
   provider,
@@ -16,9 +16,19 @@
 )
 }
 \arguments{
-\item{base_url_normalized}{Logical; set TRUE when base_url is already normalized}
+\item{provider}{Character identifier of the model provider.}
+\item{base_url}{Base URL of the provider's API.}
+\item{models_df}{Data frame of models to expand into rows.}
+\item{availability}{Character vector indicating model availability.}
+\item{src}{Source of the model information.}
+\item{ts}{Numeric timestamp when the data were cached.}
+\item{status}{Character string describing the request status.}
+\item{base_url_normalized}{Logical; set \code{TRUE} when \code{base_url} is already normalized.}
+}
+\value{
+A data frame with one row per model and a diagnostic attribute.
 }
 \description{
-list_models() helper
+Builds a data frame representing model information returned by a provider.
 }
 \keyword{internal}


### PR DESCRIPTION
## Summary
- Expand `.as_models_df` docs with title, description, parameters, and return value
- Document all `.row_df` arguments and return value for clearer models cache usage
- Refresh generated man pages for internal helpers

## Testing
- ⚠️ `R -q -e "devtools::document()"` *(failed: R not installed)*
- ⚠️ `apt-get update` *(failed: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- ⚠️ `R -q -e "devtools::test()"` *(failed: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb213f5bb4832186b1f66bcf8b92ff