### PR TITLE
Rename cache utilities with source/timestamp parameters

### DIFF
--- a/R/models_cache.R
+++ b/R/models_cache.R
@@ -351,7 +351,7 @@
 
     if (isTRUE(refresh)) {
         live <- .fetch_models_live(provider, root, refresh = TRUE, openai_api_key = openai_api_key)
-        return(.row_df(provider, root, live$df, availability, "live", now,
+        return(.row_df(provider, root, live$df, availability, source = "live", timestamp = now,
                        status = live$status, base_url_normalized = TRUE))
     }
 
@@ -366,7 +366,7 @@
         }
         if (use_cache) {
             status <- if (identical(provider, "openai")) "ok_cache" else NA_character_
-            return(.row_df(provider, root, ent$models, availability, "cache", ent$ts,
+            return(.row_df(provider, root, ent$models, availability, source = "cache", timestamp = ent$ts,
                            status = status, base_url_normalized = TRUE))
         }
     }
@@ -392,7 +392,7 @@
             ts <- .cache_get(provider, root, base_url_normalized = TRUE)$ts
         }
     }
-    .row_df(provider, root, mods, availability, "live", ts, status = status, base_url_normalized = TRUE)
+    .row_df(provider, root, mods, availability, source = "live", timestamp = ts, status = status, base_url_normalized = TRUE)
 }
 
 # --- Public API --------------------------------------------------------------

--- a/R/utils-cache.R
+++ b/R/utils-cache.R
@@ -53,10 +53,10 @@
 #' list_models() helper
 #' @keywords internal
 #' @param base_url_normalized Logical; set TRUE when base_url is already normalized
-.row_df <- function(provider, base_url, models_df, availability, src, ts, status = NA_character_, base_url_normalized = FALSE) {
+.row_df <- function(provider, base_url, models_df, availability, source, timestamp, status = NA_character_, base_url_normalized = FALSE) {
     base_url <- if (base_url_normalized) base_url else .api_root(base_url)
     models_df <- .as_models_df(models_df)
-    ts <- if (length(ts)) ts else NA_real_  # coalesce: legacy cache entries may omit ts
+    timestamp <- if (length(timestamp)) timestamp else NA_real_  # coalesce: legacy cache entries may omit timestamp
 
     if (nrow(models_df) == 0) {
         df <- data.frame(
@@ -80,8 +80,8 @@
         model_id = models_df$id,
         created = models_df$created,
         availability = availability,
-        cached_at = as.POSIXct(ts, origin = "1970-01-01", tz = "UTC"),
-        source = src,
+        cached_at = as.POSIXct(timestamp, origin = "1970-01-01", tz = "UTC"),
+        source = source,
         status = status,
         stringsAsFactors = FALSE
     )

--- a/man/dot-row_df.Rd
+++ b/man/dot-row_df.Rd
@@ -9,8 +9,8 @@
   base_url,
   models_df,
   availability,
-  src,
-  ts,
+  source,
+  timestamp,
   status = NA_character_,
   base_url_normalized = FALSE
 )

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -334,7 +334,7 @@ test_that(".as_models_df - handles df/character/named vectors/lists", {
 test_that(".row_df repeats provider/base/url and status", {
   f <- getFromNamespace(".row_df", "gptr")
   models <- .as_models_df(data.frame(id = c("a", "b"), created = c(10, 20)))
-  r <- f("openai", "https://api.openai.com", models, "catalog", "live", fixed_ts, status = "ok")
+  r <- f("openai", "https://api.openai.com", models, "catalog", source = "live", timestamp = fixed_ts, status = "ok")
   expect_equal(unique(r$provider), "openai")
   expect_equal(nrow(r), 2)
   expect_equal(r$status, rep("ok", 2))
@@ -344,14 +344,14 @@ test_that(".row_df repeats provider/base/url and status", {
 test_that(".row_df returns zero rows when no models and status is NA", {
   f <- getFromNamespace(".row_df", "gptr")
   r <- f("openai", "https://api.openai.com", data.frame(id = character(), created = numeric()),
-         "catalog", "live", fixed_ts)
+         "catalog", source = "live", timestamp = fixed_ts)
   expect_equal(nrow(r), 0)
 })
 
 test_that(".row_df preserves status when no models", {
   f <- getFromNamespace(".row_df", "gptr")
   r <- f("openai", "https://api.openai.com", data.frame(id = character(), created = numeric()),
-         "catalog", "live", fixed_ts, status = "auth_missing")
+         "catalog", source = "live", timestamp = fixed_ts, status = "auth_missing")
   expect_equal(nrow(r), 0)
   diag <- attr(r, "diagnostic")
   expect_equal(diag$status, "auth_missing")


### PR DESCRIPTION
## Summary
- rename `.row_df` parameters `src`->`source` and `ts`->`timestamp`
- update all `.row_df` calls in cache helpers and tests to use named `source`/`timestamp`
- sync generated documentation for `.row_df`

## Testing
- `R -q -e 'devtools::document()'` *(fails: command not found)*
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb213f3de88321a1412b6210270226