### PR TITLE
Remove obsolete NULL model resolution test

### DIFF
--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -134,18 +134,6 @@ test_that("auto + unknown model errors asking for provider", {
     expect_identical(called, character())
 })
 
-test_that("auto + model resolution returning NULL errors asking for provider", {
-    testthat::local_mocked_bindings(
-        .resolve_model_provider = function(model, openai_api_key = "", ...) NULL,
-        .env = asNamespace("gptr")
-    )
-    expect_error(
-        gpt("hi", model = "missing", provider = "auto", print_raw = FALSE),
-        "Model 'missing' is not available; specify a provider.",
-        fixed = TRUE
-    )
-})
-
 test_that("auto + model resolution returning empty data frame errors asking for provider", {
     testthat::local_mocked_bindings(
         .resolve_model_provider = function(model, openai_api_key = "", ...) {


### PR DESCRIPTION
## Summary
- drop `auto + model resolution returning NULL` test from backend suite
- retain empty data-frame handling coverage

## Testing
- `R -q -e 'devtools::test()'` *(failed: command not found)*
- `apt-get update` *(failed: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6db74b948321b6eb972b1b28e88e