### PR TITLE
Combine model resolution error tests into loop

### DIFF
--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -134,31 +134,27 @@ test_that("auto + unknown model errors asking for provider", {
     expect_identical(called, character())
 })
 
-test_that("auto + model resolution returning NULL errors asking for provider", {
-    testthat::local_mocked_bindings(
-        .resolve_model_provider = function(model, openai_api_key = "", ...) NULL,
-        .env = asNamespace("gptr")
+test_that("auto + model resolution returning no results errors asking for provider", {
+    no_results <- list(
+        NULL,
+        data.frame(
+            provider = character(),
+            base_url = character(),
+            model_id = character(),
+            stringsAsFactors = FALSE
+        )
     )
-    expect_error(
-        gpt("hi", model = "missing", provider = "auto", print_raw = FALSE),
-        "Model 'missing' is not available; specify a provider.",
-        fixed = TRUE
-    )
-})
-
-test_that("auto + model resolution returning empty data frame errors asking for provider", {
-    testthat::local_mocked_bindings(
-        .resolve_model_provider = function(model, openai_api_key = "", ...) {
-            data.frame(provider = character(), base_url = character(),
-                       model_id = character(), stringsAsFactors = FALSE)
-        },
-        .env = asNamespace("gptr")
-    )
-    expect_error(
-        gpt("hi", model = "missing", provider = "auto", print_raw = FALSE),
-        "Model 'missing' is not available; specify a provider.",
-        fixed = TRUE
-    )
+    for (res in no_results) {
+        testthat::local_mocked_bindings(
+            .resolve_model_provider = function(model, openai_api_key = "", ...) res,
+            .env = asNamespace("gptr")
+        )
+        expect_error(
+            gpt("hi", model = "missing", provider = "auto", print_raw = FALSE),
+            "Model 'missing' is not available; specify a provider.",
+            fixed = TRUE
+        )
+    }
 })
 
 test_that("auto with no local backend falls back to OpenAI", {


### PR DESCRIPTION
## Summary
- Replace separate NULL and empty data frame tests for `.resolve_model_provider` with a single loop over representative inputs.
- Assert the provider error is raised for both `NULL` and empty data frame resolutions.

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6da5ce30832187a59eef05784711