### PR TITLE
Ensure package namespace is mocked in missing model test

### DIFF
--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -215,7 +215,8 @@ test_that("missing openai model falls back to default", {
         request_openai = function(payload, base_url, api_key, timeout = 30) {
             used <<- payload$model
             fake_resp(model = payload$model %||% "gpt-4o-mini")
-        }
+        },
+        .env = asNamespace("gptr")
     )
     res <- gpt("hi", model = "unknown", provider = "openai",
                openai_api_key = "sk-test", print_raw = FALSE)


### PR DESCRIPTION
## Summary
- Ensure mocked functions in "missing openai model" test apply within the gptr namespace

## Testing
- `Rscript -e 'devtools::test()'` *(fails: command not found: Rscript)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6c00a980832188c36d8db2c48c1b