### PR TITLE
Use expect_length for local model test

### DIFF
--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -70,7 +70,7 @@ test_that("auto + local model routes to local", {
     )
     res <- gpt("hi", model = "mistralai/mistral-7b-instruct-v0.3",
                provider = "auto", print_raw = FALSE)
-    expect_true(length(called) == 1L)
+    expect_length(called, 1)
     expect_match(called, "^local@http://127\\.0\\.0\\.1:1234$")
 })
 


### PR DESCRIPTION
## Summary
- use `expect_length()` to check call count in local model routing test

## Testing
- ⚠️ `R -q -e 'devtools::test()'` *(failed: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6bf841ec83219dec91143eaa5545