### PR TITLE
refactor: drop backend autoswitch arg

### DIFF
--- a/R/gpt.R
+++ b/R/gpt.R
@@ -32,7 +32,6 @@ gpt <- function(prompt,
                 response_format = NULL,
                 backend = NULL,
                 strict_model = getOption("gptr.strict_model", TRUE),
-                allow_backend_autoswitch = getOption("gptr.local_autoswitch", TRUE),
                 print_raw = FALSE,
                 ...) {
 

--- a/man/gpt.Rd
+++ b/man/gpt.Rd
@@ -17,7 +17,6 @@ gpt(
   response_format = NULL,
   backend = NULL,
   strict_model = getOption("gptr.strict_model", TRUE),
-  allow_backend_autoswitch = getOption("gptr.local_autoswitch", TRUE),
   print_raw = FALSE,
   ...
 )


### PR DESCRIPTION
## Summary
- drop `allow_backend_autoswitch` argument and related option lookup from `gpt()`
- update `gpt` documentation to match signature

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_68bb704179cc8321973b9aa8bb3e644b