### PR TITLE
refactor: centralize test mocks with helper

### DIFF
--- a/tests/testthat/helper-mock.R
+++ b/tests/testthat/helper-mock.R
@@ -1,5 +1,5 @@
 local_gptr_mock <- function(..., .envir = parent.frame()) {
-    testthat::local_mocked_bindings(...,
-                                    .env = asNamespace("gptr"),
-                                    .local_envir = .envir)
+    testthat::local_mocked_bindings(
+        ..., .env = asNamespace("gptr"), .local_envir = .envir
+    )
 }

--- a/tests/testthat/helper-models_cache.R
+++ b/tests/testthat/helper-models_cache.R
@@ -39,7 +39,7 @@ mock_http_openai <- function(status = 200L,
     function(req) resp
   }
 
-  httr2::local_mock(handler, .local_envir = parent.frame())
+  httr2::local_mock(handler)
   invisible(TRUE)
 }
 


### PR DESCRIPTION
## Summary
- add `local_gptr_mock()` helper to wrap `local_mocked_bindings` for the gptr namespace
- switch backend tests to `httr2::local_mock()` and the new helper, removing direct `local_mocked_bindings` calls
- drop explicit `.local_envir` usage in test helpers

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found: R)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bc12960be8832186df5ab17b1aa11e