### PR TITLE
test: cover request_local errors and cache reuse

### DIFF
--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -439,6 +439,50 @@ test_that("gpt surfaces parse errors from request_local", {
     )
 })
 
+test_that("mocked request_local HTTP 200 invalid JSON surfaces parse error", {
+    local_gptr_mock(
+        .fetch_models_cached = function(provider = NULL, base_url = NULL,
+                                        openai_api_key = "", ...) {
+            list(df = data.frame(id = "mistral-7b", stringsAsFactors = FALSE),
+                 status = "ok")
+        },
+        request_local = function(payload, base_url, timeout = 30) {
+            stop("Local backend HTTP 200 at http://127.0.0.1:1234\nBody: {", call. = FALSE)
+        }
+    )
+    expect_error(
+        gpt("hi",
+            provider = "local",
+            model = "mistral-7b",
+            base_url = "http://127.0.0.1:1234",
+            print_raw = FALSE),
+        "Local backend HTTP 200",
+        fixed = FALSE
+    )
+})
+
+test_that("mocked request_local HTTP 500 propagates error message", {
+    local_gptr_mock(
+        .fetch_models_cached = function(provider = NULL, base_url = NULL,
+                                        openai_api_key = "", ...) {
+            list(df = data.frame(id = "mistral-7b", stringsAsFactors = FALSE),
+                 status = "ok")
+        },
+        request_local = function(payload, base_url, timeout = 30) {
+            stop("Local backend error: boom (http://127.0.0.1:1234)", call. = FALSE)
+        }
+    )
+    expect_error(
+        gpt("hi",
+            provider = "local",
+            model = "mistral-7b",
+            base_url = "http://127.0.0.1:1234",
+            print_raw = FALSE),
+        "Local backend error: boom",
+        fixed = TRUE
+    )
+})
+
 test_that("no backend mocks persist across tests", {
     expect_identical(gptr:::.resolve_model_provider, .orig_resolve_model_provider)
     expect_identical(gptr:::.fetch_models_cached, .orig_fetch_models_cached)

--- a/tests/testthat/test-models_cache.R
+++ b/tests/testthat/test-models_cache.R
@@ -212,6 +212,24 @@ test_that(".fetch_models_cached retries after unreachable and caches", {
   expect_identical(cached$models$id, "m1")
 })
 
+test_that(".fetch_models_cached caches repeated calls", {
+  fake_cache <- make_fake_cache()
+  calls <- 0
+  f <- getFromNamespace(".fetch_models_cached", "gptr")
+  local_gptr_mock(
+    .fetch_models_live = function(provider, base_url) {
+      calls <<- calls + 1
+      list(df = data.frame(id = "m1", created = 1), status = "ok")
+    },
+    .cache_get = function(p, u) fake_cache$get(p, u),
+    .cache_put = function(p, u, m) fake_cache$put(p, u, m)
+  )
+  out1 <- f("lmstudio", "http://127.0.0.1:1234")
+  out2 <- f("lmstudio", "http://127.0.0.1:1234")
+  expect_identical(calls, 1L)
+  expect_identical(out2$df$id, "m1")
+})
+
 
 
 # list models


### PR DESCRIPTION
## Summary
- test mocked request_local parse error and HTTP 500 propagation
- verify .fetch_models_cached reuses cached entries

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bc128a29088321b00d2f926acf2301