### PR TITLE
test: ensure backend options reset

### DIFF
--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -439,8 +439,10 @@ test_that("gpt surfaces parse errors from request_local", {
     )
 })
 
-test_that("no backend mocks persist across tests", {
+test_that("no backend mocks or options persist across tests", {
     expect_identical(gptr:::.resolve_model_provider, .orig_resolve_model_provider)
     expect_identical(gptr:::.fetch_models_cached, .orig_fetch_models_cached)
+    current_opts <- options()[grepl("^gptr\\.", names(options()))]
+    expect_identical(current_opts, .gptr_default_options)
 })
 


### PR DESCRIPTION
## Summary
- Confirm that backend mocks and gptr.* options are restored after backend tests

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1288cf4483219e69c7da078f72ac