### PR TITLE
chore: release v0.4.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gptr
 Type: Package
 Title: High-Level R Interface to LLM APIs for Structured Text Extraction
-Version: 0.4.1
+Version: 0.4.4
 Author: Francesco Monti
 Maintainer: Francesco Monti <francesco.monti@outlook.it>
 Description: Provides a set of high-level helper functions to interact with 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,10 @@
-# gptr (development version)
+# gptr 0.4.4
 
-* Renamed internal helpers for clarity: `.collect_local_models` → `.fetch_local_models_cached` and `.collect_openai_models` → `.fetch_openai_models_cached`.
-* `.fetch_models_live` now handles OpenAI and local providers directly; removed provider-specific helpers.
-* `list_models()` now defaults to `refresh = FALSE`; use new `refresh_models()` (replacing `refresh_models_cache()`) to force a live probe.
+* Overhauled model caching and fetching: consolidated helpers under cachem, `.fetch_models_live()` now handles OpenAI and local providers directly, `list_models()` caches by default with a new `refresh_models()` to force a live probe, and redundant base URL normalization was removed.
+* Renamed internal helpers for clarity and streamlined provider lookup.
+* `request_local()` is now internal.
+* Dropped remote withr dependency and replaced typographic quotes.
+* Added documentation for `assemble_models_df()` and expanded test coverage around model cache helpers.
 
 # gptr 0.4.3
 Removed legacy backend helpers and detection functions.


### PR DESCRIPTION
## Summary
- expand 0.4.4 release notes with additional changes
- tag release v0.4.4

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bf254ca3d8832186a1fe174783faa4