### PR TITLE
Define found flag before model availability check

### DIFF
--- a/R/gpt.R
+++ b/R/gpt.R
@@ -48,6 +48,7 @@ gpt <- function(prompt,
             rlang::abort(sprintf("Model '%s' is not available; specify a provider.", model))
         }
         hits <- lm
+        found <- nrow(hits) > 0
         prefer_locals <- getOption("gptr.local_prefer", c("lmstudio","ollama","localai"))
         rank_fn <- function(p) {
             m <- match(p, c(prefer_locals, "openai"))


### PR DESCRIPTION
## Summary
- Ensure `found` flag is defined based on model hits before checking backend availability in `gpt()`.

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called ‘testthat’)*


------
https://chatgpt.com/codex/tasks/task_e_68c2de13fec883218eb566477d343317