### PR TITLE
Document backend and model parameters in gpt_column

### DIFF
--- a/R/gpt_column.R
+++ b/R/gpt_column.R
@@ -11,8 +11,10 @@
 #'   Fuzzy key correction is handled by json_keys_align(); control with `fuzzy_model`
 #'   ("lev_ratio" or "lev") and `fuzzy_threshold`.
 #' @param keep_unexpected_keys Keep keys not listed in `keys`.
-#' @param Provider One of "auto", "local", "openai", "lmstudio", "ollama", "localai".
+#' @param provider One of "auto", "local", "openai", "lmstudio", "ollama", "localai".
+#' @param backend Optional backend to use when `provider = "local"`.
 #' @param base_url (now accepted by gpt_column() too): “Optional. Pin a specific local endpoint (…/v1 or …/v1/chat/completions).”
+#' @param model Model identifier to request from the provider/backend.
 #' @param na_values Values treated as NA at multiple stages.
 #' @param file_path,image_path Optional file paths passed to the model call.
 #' @param temperature Sampling temperature for the model.
@@ -24,7 +26,7 @@
 #' @param infer_types Logical; when no schema is provided, infer column types (default FALSE).
 #'   If a schema (`keys`) is provided, it is always used for final typing.
 #' @param progress Logical. Progress Bar, defaults to TRUE.
-#' @param ... Extra args passed to `gpt()` (e.g., `model`, `provider`,`response_format`).
+#' @param ... Extra args passed to `gpt()` (e.g., `response_format`).
 #' @export
 
 gpt_column <- function(data,


### PR DESCRIPTION
## Summary
- Document `provider`, `backend`, and `model` parameters in `gpt_column`
- Clarify ellipsis documentation for extra `gpt()` arguments

## Testing
- `R -q -e "devtools::test()"` *(fails: `R` command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c43828ad28832186ccec8a8f329bb4