### PR TITLE
Use gptr.* options in LM Studio integration test

### DIFF
--- a/tests/testthat/test-integration-lmstudio.R
+++ b/tests/testthat/test-integration-lmstudio.R
@@ -3,10 +3,10 @@ test_that("LM Studio fast path works (pinned)", {
     message = "Set Sys.setenv(GPTR_INTEGRATION = \"1\") to run"
   )
   options(
-    gpt.provider = "auto",
-    gpt.local_base_url = "http://127.0.0.1:1234/v1/chat/completions",
-    gpt.local_model = "mistralai/mistral-7b-instruct-v0.3",
-    gpt.verbose_preflight = TRUE
+    gptr.provider = "auto",
+    gptr.local_base_url = "http://127.0.0.1:1234/v1/chat/completions",
+    gptr.local_model = "mistralai/mistral-7b-instruct-v0.3",
+    gptr.verbose_preflight = TRUE
   )
   out <- gpt("ping", provider = "lmstudio", print_raw = FALSE, temperature = 0)
   expect_type(out, "character")
@@ -18,7 +18,7 @@ test_that("Default URL with helpful error if LM Studio down", {
   testthat::skip_if(Sys.getenv("GPTR_INTEGRATION") != "1",
     message = "Set Sys.setenv(GPTR_INTEGRATION = \"1\") to run"
   ) # run when you want to check message
-  options(gpt.local_base_url = NULL)
+  options(gptr.local_base_url = NULL)
   if (!curl::has_internet()) skip("no internet utils")
   # If LM Studio is not running, this should error with guidance.
   # If it is running, this should pass and return text.
@@ -26,7 +26,7 @@ test_that("Default URL with helpful error if LM Studio down", {
   if (inherits(res, "try-error")) {
     expect_match(
       conditionMessage(attr(res, "condition")),
-      "Pass `base_url=` or set options\\(gpt\\.lmstudio_base_url=\\)\\."
+      "Pass `base_url=` or set options\\(gptr\\.lmstudio_base_url=\\)\\."
     )
   } else {
     expect_true(is.character(res))


### PR DESCRIPTION
## Summary
- refactor LM Studio integration tests to use `gptr.*` option names
- update error message guidance to reference `gptr.lmstudio_base_url`

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c438384ce0832198917284a1686935