### PR TITLE
Clean backend parameter documentation

### DIFF
--- a/R/gpt.R
+++ b/R/gpt.R
@@ -8,7 +8,7 @@
 #' @param temperature Numeric scalar (default 0.2).
 #' @param provider One of "auto", "local", "openai", "lmstudio", "ollama", "localai".
 #' @param base_url "Optional. Pin a specific local endpoint (…/v1 or …/v1/chat/completions)."
-#' @param backend "Optional. When provider is local, choose a running backend ('lmstudio', 'ollama', 'localai')."
+#' @param backend Optional. When provider is local, choose a running backend ('lmstudio', 'ollama', 'localai').
 #' @param openai_api_key Optional API key for OpenAI; defaults to env var.
 #' @param image_path Optional path or vector of paths to images to include.
 #' @param system Optional system prompt.

--- a/man/gpt.Rd
+++ b/man/gpt.Rd
@@ -43,7 +43,7 @@ gpt(
 
 \item{response_format}{NULL, "json_object", or a full list (OpenAI API shape).}
 
-\item{backend}{"Optional. When provider is local, choose a running backend ('lmstudio', 'ollama', 'localai')."}
+\item{backend}{Optional. When provider is local, choose a running backend ('lmstudio', 'ollama', 'localai').}
 
 \item{strict_model}{Logical. If TRUE (default), error if the requested model is
 unavailable on the chosen backend.}


### PR DESCRIPTION
## Summary
- remove superfluous quotes from the `backend` parameter description in `gpt()`
- update the generated Rd documentation to keep the public docs consistent

## Testing
- not run (Rscript unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c91dd7c7cc83219f0be21f3c01bf70