### PR TITLE
Add test for local base_url normalization

### DIFF
--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -290,6 +290,32 @@ test_that("explicit local base_url is honored", {
     expect_identical(called, "local@http://192.168.1.50:1234")
 })
 
+test_that("local base_url path variants are normalized", {
+    urls <- c("http://custom:1234/v1", "http://custom:1234/v1/chat/completions")
+    testthat::local_mocked_bindings(
+        .fetch_models_cached = function(provider = NULL, base_url = NULL,
+                                            openai_api_key = "", ...) {
+            data.frame(model_id = "custom-model", stringsAsFactors = FALSE)
+        },
+        .request_local = function(payload, base_url, timeout = 30) {
+            captured <<- c(captured, base_url)
+            fake_resp(model = payload$model %||% "custom-model")
+        },
+        .env = asNamespace("gptr")
+    )
+
+    for (url in urls) {
+        captured <- character()
+        gpt("hi",
+            provider = "local",
+            base_url = url,
+            model = "custom-model",
+            strict_model = TRUE,
+            print_raw = FALSE)
+        expect_identical(captured, "http://custom:1234")
+    }
+})
+
 test_that("strict_model errors when model not installed (local)", {
     testthat::local_mocked_bindings(
         .fetch_models_cached = function(provider = NULL, base_url = NULL,


### PR DESCRIPTION
## Summary
- add coverage ensuring `gpt()` normalizes custom local `base_url` values before invoking the backend

## Testing
- Rscript -e 'testthat::test_file("tests/testthat/test-backends.R")' *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c91dd6515c8321a4dfb367d1d06228