### PR TITLE
Add ssl_cert option for HTTP requests

### DIFF
--- a/man/gpt.Rd
+++ b/man/gpt.Rd
@@ -19,6 +19,7 @@ gpt(
   strict_model = getOption("gptr.strict_model", TRUE),
   allow_backend_autoswitch = getOption("gptr.local_autoswitch", TRUE),
   print_raw = FALSE,
+  ssl_cert = getOption("gptr.ssl_cert", NULL),
   ...
 )
 }
@@ -53,6 +54,8 @@ probe or switch to alternative local backends if the requested one is
 unavailable.}
 
 \item{print_raw}{Logical. If TRUE, pretty-print a compact response skeleton and return it immediately (skips any post-processing). Default FALSE.}
+
+\item{ssl_cert}{Optional path to a certificate authority (CA) bundle passed to provider HTTP clients as \code{cainfo}.}
 
 \item{...}{Extra fields passed through to the provider payload (e.g. \code{max_tokens}, \code{stop}).}
 }

--- a/man/openai_send_request.Rd
+++ b/man/openai_send_request.Rd
@@ -8,7 +8,8 @@ openai_send_request(
   payload,
   base_url = NULL,
   api_key = NULL,
-  timeout = getOption("gptr.timeout", 30)
+  timeout = getOption("gptr.timeout", 30),
+  ssl_cert = NULL
 )
 }
 \arguments{
@@ -19,6 +20,9 @@ openai_send_request(
 \item{api_key}{OpenAI API key (default: Sys.getenv("OPENAI_API_KEY"))}
 
 \item{timeout}{seconds (numeric)}
+
+\item{ssl_cert}{Optional path to a certificate authority (CA) bundle passed to
+\code{httr2::req_options} as \code{cainfo} for HTTPS verification.}
 }
 \value{
 list with \code{body}, \code{resp} (httr2 response). Use \code{openai_parse_text()} to get text.


### PR DESCRIPTION
## Summary
- add an optional `ssl_cert` argument to the OpenAI and local request helpers so HTTPS verification can use custom CA bundles
- allow `gpt()` to accept and forward the `ssl_cert` option to provider-specific calls and document the new parameter
- extend backend tests to exercise the new option and verify request objects receive the configured certificate path

## Testing
- `Rscript -e "roxygen2::roxygenise()"` *(fails: command not found)*
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c91e9f2b7c8321b151fe14c8047ad1