### PR TITLE
Return raw skeleton invisibly when printing raw responses

### DIFF
--- a/R/gpt.R
+++ b/R/gpt.R
@@ -219,14 +219,14 @@ gpt <- function(prompt,
         if (isTRUE(print_raw)) {
             sk <- .to_skeleton(res$body)
             cat(jsonlite::toJSON(sk, auto_unbox = TRUE, pretty = TRUE), "\n")
-            return(sk)
+            return(invisible(sk))
         }
         parsed <- openai_parse_text(res$body)
         out <- parsed$text
         attr(out, "usage") <- parsed$usage
         attr(out, "backend") <- backend_name
         attr(out, "model") <- model_name
-        out
+        return(out)
     }
 
     image_paths <- if (is.null(image_path)) NULL else as.character(image_path)


### PR DESCRIPTION
## Summary
- return the raw response skeleton invisibly when `print_raw` is `TRUE` to avoid automatic printing
- explicitly return parsed text when `print_raw` is `FALSE` to preserve the prior behavior

## Testing
- Attempted `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: R command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c925ed687c8321a876b5f1c21518ca