### PR TITLE
Clarify print_raw docs without modifying generated Rd

### DIFF
--- a/R/gpt.R
+++ b/R/gpt.R
@@ -19,10 +19,15 @@
 #' @param allow_backend_autoswitch Logical (default TRUE). When FALSE, do not
 #'   probe or switch to alternative local backends if the requested one is
 #'   unavailable.
-#' @param print_raw Logical. If TRUE, pretty-print a compact response skeleton and return it immediately (skips any post-processing). Default FALSE.
+#' @param print_raw Logical. If TRUE, pretty-print the compact response
+#'   skeleton as JSON in the console and return that skeleton list instead of
+#'   the assistant text (skipping any downstream post-processing). Default
+#'   FALSE.
 #' @param ... Extra fields passed through to the provider payload (e.g. `max_tokens`, `stop`).
 #'
-#' @return Character scalar (assistant message). `attr(value, "usage")` may contain token usage.
+#' @return Character scalar (assistant message). `attr(value, "usage")` may
+#'   contain token usage. When `print_raw = TRUE`, prints a JSON skeleton to the
+#'   console and returns that skeleton list instead of the assistant text.
 #' @export
 #'
 gpt <- function(prompt,


### PR DESCRIPTION
## Summary
- document that `print_raw` prints the JSON skeleton and returns that list in the `gpt()` roxygen comments
- remove manual edits to `man/gpt.Rd` so the generated documentation stays in sync with the source roxygen block

## Testing
- Rscript -e "sessionInfo()" *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c925de50dc8321910062d3d9ea2e98